### PR TITLE
install from git repository

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,17 @@ class Sdist(setuptools.command.sdist.sdist):
 cmdclass['sdist'] = Sdist
 
 
+class Install(setuptools.command.install.install):
+
+    def run(self):
+        if not os.path.isdir('omero_parade/static/omero_parade/js'):
+            self.run_command('run_prod')
+        setuptools.command.install.install.run(self)
+
+
+cmdclass['install'] = Install
+
+
 setup(name="omero-parade",
       packages=find_packages(exclude=['ez_setup']),
       version=VERSION,


### PR DESCRIPTION
Add install command so parade can be installed from a git repository
using ``pip install git+git:...``
This is needed so it can be deployed as part of the daily build

To test locally install from git:
* run ``pip install  git+git://github.com/jburel/omero-parade.git@build-review#egg=omero-parade``
* Check that it is correctly installed
* uninstall

Nothing should be rebuilt when installing from pypi
For testing purpose, i have registered omero-parade on testpypi
To test locally install from testpypi:

* run ``pip install --index-url https://test.pypi.org/simple/ omero-parade``
* Check that it is correctly installed
* uninstall


