### PR TITLE
Sparklines

### DIFF
--- a/omero_parade/static/omero_parade/css/parade.css
+++ b/omero_parade/static/omero_parade/css/parade.css
@@ -94,6 +94,11 @@ ul {
   margin-left: 5px;
 }
 
+.filterContainer input[type='range'] {
+  position: relative;
+  top: 4px;
+}
+
 .plateGrid, .centrePanel {
   flex: 1;
   width: 100%;

--- a/omero_parade/static/omero_parade/css/parade.css
+++ b/omero_parade/static/omero_parade/css/parade.css
@@ -88,6 +88,7 @@ ul {
 
 .parade_filter {
   margin: 5px;
+  clear: both;
 }
 
 .filterContainer input, .filterContainer select {

--- a/omero_parade/static/omero_parade/css/parade.css
+++ b/omero_parade/static/omero_parade/css/parade.css
@@ -391,3 +391,27 @@ input[type=range].parade:focus::-ms-fill-upper {
 .parade_filter:hover .parade_removeFilter {
   visibility: visible;
 }
+
+.parade_filter .sparkline {
+  padding-top: 2px;
+  margin: 0px 5px;
+  font-size: 12px;
+  float: left;
+}
+
+.parade_filter .sparkline .minimum {
+  margin-right: 2px;
+}
+
+.parade_filter .sparkline .maximum {
+  margin-left: 2px;
+}
+
+.parade_filter .sparkline svg {
+  height: 18px;
+  width: 36px;
+}
+
+.parade_filter_controls {
+  float: left;
+}

--- a/omero_parade/static/omero_parade/css/parade.css
+++ b/omero_parade/static/omero_parade/css/parade.css
@@ -96,7 +96,7 @@ ul {
 
 .filterContainer input[type='range'] {
   position: relative;
-  top: 4px;
+  top: 6px;
 }
 
 .plateGrid, .centrePanel {
@@ -399,7 +399,7 @@ input[type=range].parade:focus::-ms-fill-upper {
 
 .parade_filter .sparkline {
   padding-top: 2px;
-  margin: 0px 5px;
+  margin: 8px 5px 0px;
   font-size: 12px;
   float: left;
 }

--- a/omero_parade/views.py
+++ b/omero_parade/views.py
@@ -31,7 +31,9 @@ from django.shortcuts import render
 from . import parade_settings
 
 
-NUMPY_1_11_0 = LooseVersion('1.11.0')
+NUMPY_GT_1_11_0 = False
+if LooseVersion(numpy.__version__) > LooseVersion('1.11.0'):
+    NUMPY_GT_1_11_0 = True
 
 
 def index(request):
@@ -167,7 +169,7 @@ def get_data(request, data_name, conn=None, **kwargs):
                                                           conn)
                     values = numpy.array(data.values())
                     bins = 10
-                    if LooseVersion(numpy.__version__) > NUMPY_1_11_0:
+                    if NUMPY_GT_1_11_0:
                         # numpy.histogram() only supports bin calculation
                         # from 1.11.0 onwards
                         bins = 'auto'

--- a/omero_parade/views.py
+++ b/omero_parade/views.py
@@ -17,16 +17,21 @@
 
 """Django views methods."""
 
+import numpy
 import omero
 import omero.clients
 
 from base64 import b64decode
+from distutils.version import LooseVersion
 
 from django.http import Http404, JsonResponse
 from omeroweb.webclient.decorators import login_required
 from omero.rtypes import rlong, unwrap
 from django.shortcuts import render
 from . import parade_settings
+
+
+NUMPY_1_11_0 = LooseVersion('1.11.0')
 
 
 def index(request):
@@ -160,7 +165,19 @@ def get_data(request, data_name, conn=None, **kwargs):
                 if data_name in dp:
                     data = module.data_providers.get_data(request, data_name,
                                                           conn)
-                    return JsonResponse({'data': data})
+                    values = numpy.array(data.values())
+                    bins = 10
+                    if LooseVersion(numpy.__version__) > NUMPY_1_11_0:
+                        # numpy.histogram() only supports bin calculation
+                        # from 1.11.0 onwards
+                        bins = 'auto'
+                    histogram, bin_edges = numpy.histogram(values, bins=bins)
+                    return JsonResponse({
+                        'data': data,
+                        'min': numpy.amin(values),
+                        'max': numpy.amax(values),
+                        'histogram': list(histogram)
+                    })
         except ImportError:
             pass
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5873,6 +5873,14 @@
         "prop-types": "15.6.1"
       }
     },
+    "react-sparklines": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/react-sparklines/-/react-sparklines-1.7.0.tgz",
+      "integrity": "sha512-bJFt9K4c5Z0k44G8KtxIhbG+iyxrKjBZhdW6afP+R7EnIq+iKjbWbEFISrf3WKNFsda+C46XAfnX0StS5fbDcg==",
+      "requires": {
+        "prop-types": "15.6.1"
+      }
+    },
     "read-chunk": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-2.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "axios": "^0.17.1",
     "clusterfck": "^0.6.0",
     "react": "^16.2.0",
-    "react-dom": "^16.2.0"
+    "react-dom": "^16.2.0",
+    "react-sparklines": "^1.7.0"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",

--- a/src/js/dataView/Layout.js
+++ b/src/js/dataView/Layout.js
@@ -114,7 +114,7 @@ class Layout extends React.Component {
             $.getJSON(url, data => {
                 // Add data to table data
                 let td = Object.assign({}, this.state.tableData);
-                td[dataName] = data.data;
+                td[dataName] = data;
                 this.setState({
                     tableData: td
                 });

--- a/src/js/dataView/plate/PlateGrid.js
+++ b/src/js/dataView/plate/PlateGrid.js
@@ -76,7 +76,7 @@ class PlateGrid extends React.Component {
                     // lookup this Well's data from heatmap
                     // var heatmapValues = heatmapData && heatmapData[well.wellId+""];
                     // tableData is mapped to Image IDs... (well.id is image ID!)
-                    var imgTableData = Object.keys(tableData).map(col => col + ": " + tableData[col][well.id])
+                    var imgTableData = Object.keys(tableData).map(col => col + ": " + tableData[col].data[well.id])
                     return (
                         <Well
                             key={well.wellId}

--- a/src/js/dataView/plot/DataPlot.js
+++ b/src/js/dataView/plot/DataPlot.js
@@ -105,9 +105,8 @@ class DataPlot extends React.Component {
         }
         axisNames = Object.keys(tableData);
         let dataRanges = axisNames.reduce((prev, name) => {
-            let mn = Object.values(tableData[name]).reduce((p, v) => Math.min(p, v));
-            let mx = Object.values(tableData[name]).reduce((p, v) => Math.max(p, v));
-            prev[name] = [mn, mx]
+            let v = tableData[name];
+            prev[name] = [v.min, v.max];
             return prev;
         }, {});
         function getAxisPercent(name, value) {
@@ -141,8 +140,8 @@ class DataPlot extends React.Component {
                                 src={"/webgateway/render_thumbnail/" + image.id + "/"}
                                 title={image.name}
                                 onClick={event => {handleImageWellClicked(image, event)}}
-                                style={{left: getAxisPercent(xAxisName, tableData[xAxisName][image.id]) + '%',
-                                        top: (100 - getAxisPercent(yAxisName, tableData[yAxisName][image.id])) + '%'}}
+                                style={{left: getAxisPercent(xAxisName, tableData[xAxisName].data[image.id]) + '%',
+                                        top: (100 - getAxisPercent(yAxisName, tableData[yAxisName].data[image.id])) + '%'}}
                             />
                         ))}
                     </div>

--- a/src/js/dataView/table/DatasetTable.js
+++ b/src/js/dataView/table/DatasetTable.js
@@ -29,7 +29,7 @@ class DatasetTable extends React.Component {
              handleImageWellClicked} = this.props;
         if (sortBy != undefined) {
             // let orderedImageIds;
-            let colDataToSort = tableData[sortBy];
+            let colDataToSort = tableData[sortBy].data;
             // Add a sortKey to imgJson
             imgJson = imgJson.map(i => Object.assign(i, {sortKey: colDataToSort[i.id]}));
             // sort...
@@ -44,9 +44,8 @@ class DatasetTable extends React.Component {
         let columnNames = Object.keys(tableData);
 
         let dataRanges = columnNames.reduce((prev, name) => {
-            let mn = Object.values(tableData[name]).reduce((p, v) => Math.min(p, v));
-            let mx = Object.values(tableData[name]).reduce((p, v) => Math.max(p, v));
-            prev[name] = [mn, mx]
+            let v = tableData[name];
+            prev[name] = [v.min, v.max];
             return prev;
         }, {});
         function heatMapColor(name, value) {
@@ -95,9 +94,9 @@ class DatasetTable extends React.Component {
                         </td>
                         {columnNames.map(name => (
                             <td key={name}
-                                style={{backgroundColor: showHeatmapColumns[name] ? heatMapColor(name, tableData[name][image.id]): 'transparent'}}
+                                style={{backgroundColor: showHeatmapColumns[name] ? heatMapColor(name, tableData[name].data[image.id]): 'transparent'}}
                                 >
-                                {tableData[name][image.id]}
+                                {tableData[name].data[image.id]}
                             </td>
                         ))}
                     </tr>

--- a/src/js/filter/FilterContainer.js
+++ b/src/js/filter/FilterContainer.js
@@ -82,6 +82,7 @@ class FilterContainer extends React.Component {
                         <ParadeFilter
                             key={fname + idx}
                             filterIndex={idx}
+                            filterValues={this.props.filterValues[idx]}
                             name={fname}
                             parentType={this.props.parentType}
                             parentId={this.props.parentId}

--- a/src/js/filter/FilterHub.js
+++ b/src/js/filter/FilterHub.js
@@ -55,12 +55,19 @@ class FilterHub extends React.Component {
     }
 
     handleFilterChange(filterIndex, paramName, paramValue) {
-        let newValues = Object.assign({}, this.state.filterValues[filterIndex]);
-        newValues[paramName] = paramValue;
-        let filterValues = [...this.state.filterValues];    // new list
-        filterValues[filterIndex] = newValues;
-        this.setState({
-            filterValues: filterValues
+        // A parameter has changed in one of the list of filters...
+        this.setState(prevState => {
+            // Copy the previous set of values for the filter at this index...
+            let newValues = Object.assign({}, prevState.filterValues[filterIndex]);
+            // Assign the new value...
+            newValues[paramName] = paramValue;
+            // Make a copy of the previous list of parameter values
+            let filterValues = [...prevState.filterValues];
+            // And add back the new object to the correct index
+            filterValues[filterIndex] = newValues;
+            return {
+                filterValues: filterValues
+            }
         });
     }
 

--- a/src/js/filter/FilterInput.js
+++ b/src/js/filter/FilterInput.js
@@ -50,10 +50,16 @@ class FilterInput extends React.Component {
                 </select>
             )
         }
+        let type = param.type;
+        if (this.props.min != undefined && this.props.max != undefined) {
+            type = 'range';
+        }
         return (
             <input
                 name={param.name}
-                type={param.type}
+                type={type}
+                min={this.props.min}
+                max={this.props.max}
                 onChange={onChange}
                 title={param.title ? param.title : ''}
             />

--- a/src/js/filter/FilterInput.js
+++ b/src/js/filter/FilterInput.js
@@ -50,14 +50,25 @@ class FilterInput extends React.Component {
                 </select>
             )
         }
-        let type = param.type;
         if (this.props.min != undefined && this.props.max != undefined) {
-            type = 'range';
+            return (
+                <span>
+                    <span> {this.props.value}</span>
+                    <input
+                        name={param.name}
+                        type='range'
+                        min={this.props.min}
+                        max={this.props.max}
+                        onChange={onChange}
+                        title={param.title ? param.title : ''}
+                    />
+                </span>
+            )
         }
         return (
             <input
                 name={param.name}
-                type={type}
+                type={param.type}
                 min={this.props.min}
                 max={this.props.max}
                 onChange={onChange}

--- a/src/js/filter/FilterInput.js
+++ b/src/js/filter/FilterInput.js
@@ -22,6 +22,14 @@ import { getHeatmapColor } from '../util'
 
 class FilterInput extends React.Component {
 
+    constructor(props) {
+        super(props);
+
+        this.onParamSelectChanged = this.onParamSelectChanged.bind(this);
+        this.onRangeValueChanged = this.onRangeValueChanged.bind(this);
+        this.onInputValueChanged = this.onInputValueChanged.bind(this);
+    }
+
     /** Returns a figure space padded version of the current value. */
     getPaddedValue() {
         let max = this.props.max;
@@ -32,23 +40,43 @@ class FilterInput extends React.Component {
         let padding = max.toString().length - value.toString().length;
         return "\u2007".repeat(padding) + value;
     }
+
+    /**
+     * Triggered whenever the select element changes.  Dispatches the
+     * change action in a generic way, including the filter base parameter
+     * name by way of the provided singular change handler.
+     */
+    onParamSelectChanged(event) {
+        this.props.onChange(this.props.param.name, event.target.value);
+    }
+
+    /**
+     * Triggered whenever the value changes and it is a range input.
+     * Dispatches the change action in a generic way, including the
+     * filter base parameter name by way of the provided singular
+     * change handler.
+     */
+    onRangeValueChanged(event) {
+        this.props.onChange(this.props.param.name, event.target.value);
+    }
+
+    /**
+     * Triggered whenever the value changes and it is regular input.
+     * Dispatches the change action in a generic way, including the
+     * filter base parameter name by way of the provided singular
+     * change handler.
+     */
+    onInputValueChanged(event) {
+        this.props.onChange(this.props.param.name, event.target.value);
+    }
     
     render() {
         let param = this.props.param;
-        let filterChanged = this.props.onChange;
-        let onChange = function (event) {
-            let value = event.target.value;
-            if (param.type === 'number'){
-                value = parseInt(value, 10);
-            }
-            filterChanged(param.name, value);
-        }
-
         if (param.values) {
             return (
                 <select
                     name={param.name}
-                    onChange={onChange}
+                    onChange={this.onParamSelectChanged}
                     title={param.title ? param.title : ''}
                     >
                     {param.values.map(value => (
@@ -70,7 +98,7 @@ class FilterInput extends React.Component {
                         type='range'
                         min={this.props.min}
                         max={this.props.max}
-                        onChange={onChange}
+                        onChange={this.onRangeValueChanged}
                         title={param.title ? param.title : ''}
                     />
                 </span>
@@ -82,7 +110,7 @@ class FilterInput extends React.Component {
                 type={param.type}
                 min={this.props.min}
                 max={this.props.max}
-                onChange={onChange}
+                onChange={this.onInputValueChanged}
                 title={param.title ? param.title : ''}
             />
         )

--- a/src/js/filter/FilterInput.js
+++ b/src/js/filter/FilterInput.js
@@ -21,6 +21,17 @@ import { getHeatmapColor } from '../util'
 
 
 class FilterInput extends React.Component {
+
+    /** Returns a figure space padded version of the current value. */
+    getPaddedValue() {
+        let max = this.props.max;
+        let value = this.props.value;
+        if (max == undefined) {
+            return value;
+        }
+        let padding = max.toString().length - value.toString().length;
+        return "\u2007".repeat(padding) + value;
+    }
     
     render() {
         let param = this.props.param;
@@ -53,7 +64,7 @@ class FilterInput extends React.Component {
         if (this.props.min != undefined && this.props.max != undefined) {
             return (
                 <span>
-                    <span> {this.props.value}</span>
+                    <span>{this.getPaddedValue()}</span>
                     <input
                         name={param.name}
                         type='range'

--- a/src/js/filter/ParadeFilter.js
+++ b/src/js/filter/ParadeFilter.js
@@ -68,10 +68,15 @@ class ParadeFilter extends React.Component {
     
     handleFilterInput(paramName, value) {
         this.props.handleFilterChange(this.props.filterIndex, paramName, value);
-        if (paramName !== "column_name") {
-            return;
-        }
-        let filterParam = this.state.filterParams[0];
+        // Depending on how many filter parameters we have, their type, and
+        // the availability of additional metadata this method may be invoked
+        // by several other event handlers.  The defining characteristic that
+        // allows us to recognise which `FilterInput` called us is
+        // `paramName`.  The `paramName` *should* always match *one*
+        // filter parameter.
+        let filterParam = this.state.filterParams.filter(v => {
+            return v.name === paramName;
+        })[0];
         if (filterParam.histograms) {
             this.setState({
                 histogram: filterParam.histograms[value]

--- a/src/js/filter/ParadeFilter.js
+++ b/src/js/filter/ParadeFilter.js
@@ -101,6 +101,7 @@ class ParadeFilter extends React.Component {
                                     max={this.state.maximum}
                                     key={p.name}
                                     onChange={this.handleFilterInput}
+                                    value={this.props.filterValues[p.name]}
                                 />
                     })}
                 </div>

--- a/src/js/filter/ParadeFilter.js
+++ b/src/js/filter/ParadeFilter.js
@@ -17,6 +17,7 @@
 //
 
 import React, { Component } from 'react';
+import { Sparklines, SparklinesBars } from 'react-sparklines';
 import FilterInput from './FilterInput';
 
 
@@ -67,11 +68,31 @@ class ParadeFilter extends React.Component {
     
     handleFilterInput(paramName, value) {
         this.props.handleFilterChange(this.props.filterIndex, paramName, value);
+        if (paramName !== "column_name") {
+            return;
+        }
+        let filterParam = this.state.filterParams[0];
+        if (filterParam.histograms) {
+            this.setState({
+                histogram: filterParam.histograms[value]
+            });
+        }
+        if (filterParam.minima) {
+            this.setState({
+                minimum: filterParam.minima[value]
+            });
+        }
+        if (filterParam.maxima) {
+            this.setState({
+                maximum: filterParam.maxima[value]
+            });
+        }
     }
 
     render() {
         return(
             <div className="parade_filter">
+                <div className="parade_filter_controls">
                 {this.props.name}
                 {this.state.filterParams.map(p => {
                     return <FilterInput
@@ -80,6 +101,14 @@ class ParadeFilter extends React.Component {
                                 onChange={this.handleFilterInput}
                             />
                 })}
+                </div>
+                <div className="sparkline">
+                    <span className="minimum">{this.state.minimum}</span>
+                    <Sparklines data={this.state.histogram}>
+                        <SparklinesBars />
+                    </Sparklines>
+                    <span className="maximum">{this.state.maximum}</span>
+                </div>
                 <button
                     className="parade_removeFilter"
                     onClick={() => {this.props.handleRemoveFilter(this.props.filterIndex)}}>

--- a/src/js/filter/ParadeFilter.js
+++ b/src/js/filter/ParadeFilter.js
@@ -93,14 +93,14 @@ class ParadeFilter extends React.Component {
         return(
             <div className="parade_filter">
                 <div className="parade_filter_controls">
-                {this.props.name}
-                {this.state.filterParams.map(p => {
-                    return <FilterInput
-                                param={p}
-                                key={p.name}
-                                onChange={this.handleFilterInput}
-                            />
-                })}
+                    {this.props.name}
+                    {this.state.filterParams.map(p => {
+                        return <FilterInput
+                                    param={p}
+                                    key={p.name}
+                                    onChange={this.handleFilterInput}
+                                />
+                    })}
                 </div>
                 <div className="sparkline">
                     <span className="minimum">{this.state.minimum}</span>

--- a/src/js/filter/ParadeFilter.js
+++ b/src/js/filter/ParadeFilter.js
@@ -97,6 +97,8 @@ class ParadeFilter extends React.Component {
                     {this.state.filterParams.map(p => {
                         return <FilterInput
                                     param={p}
+                                    min={this.state.minimum}
+                                    max={this.state.maximum}
                                     key={p.name}
                                     onChange={this.handleFilterInput}
                                 />


### PR DESCRIPTION
![sparkline](https://user-images.githubusercontent.com/487082/38441615-431555ba-39dd-11e8-8790-3b7edfc7f1c9.png)

This adds sparklines to the user interface via `react-sparklines`. It also moves min-max calculation and adds histogram calculation to the server. These additional metadata are now available in all OMERO.tables based filter and data retrieval API endpoints. We should be able to quite easily expand this to all numerical filters if desired.

Everything should be additive with the exception of the fact that table data now has to be of the right column type (`DoubleColumn` or `LongColumn`) and will be filtered accordingly. It will not be coerced from a `StringColumn`.

/cc @emilroz, @lunson 