### PR TITLE
Expand all for Projects

### DIFF
--- a/omero_parade/static/omero_parade/css/parade.css
+++ b/omero_parade/static/omero_parade/css/parade.css
@@ -252,6 +252,7 @@ input[type=range].parade:focus::-ms-fill-upper {
 .parade_centrePanel {
   flex-grow: 1;
   overflow: auto;
+  margin: 10px;
 }
 
 .parade_centrePanel .datasetThumb {

--- a/omero_parade/static/omero_parade/css/parade.css
+++ b/omero_parade/static/omero_parade/css/parade.css
@@ -392,3 +392,12 @@ input[type=range].parade:focus::-ms-fill-upper {
 .parade_filter:hover .parade_removeFilter {
   visibility: visible;
 }
+
+.parade_openAll {
+  width: 100%;
+  text-align: center;
+}
+
+.parade_openAll h1 {
+  text-align: center;
+}

--- a/omero_parade/templates/omero_parade/init.js.html
+++ b/omero_parade/templates/omero_parade/init.js.html
@@ -11,40 +11,16 @@ $(function() {
   window.PARADE_INDEX_URL = "{% url 'parade_index' %}";
   window.PARADE_DATAPROVIDERS_URL = "{% url 'parade_dataproviders' %}";
 
-
-  // TODO: this should be handled by omeroweb_center_plugin()
-  // to call load_plugin_content() when needed.
-  // Start listening for Node Loading events on the tree...
-  // If a node loads and it's selected, update_thumbs...
-  let treeChanged = function(event, data){
-      // update_thumbnails_panel(event, data);
-      var datatree = $.jstree.reference('#dataTree');
-      if (!datatree) return;
-      var tree_selected = datatree.get_selected(true);
-      omero_parade.omero_parade(tree_selected, datatree);
-  }
-
-  $("#dataTree").on('load_node.jstree', treeChanged)
-                .on('open_node.jstree', treeChanged)
-                .on('close_node.jstree', treeChanged);
-
-
   $("#omero_parade").omeroweb_center_plugin({
     plugin_index: pluginIndex,        // From the Django template loop
     empty_on_sel_change: false,       // Do not completely erase content when changing selection
     load_plugin_content: function(selected, dtype, oid) {
-
       // this may have been called before datatree was initialised...
-      var datatree = $.jstree.reference('#dataTree');
-      if (!datatree) return;
-
-      // We use the tree to access selected objects, since we can traverse
-      // to check parents etc...
-      // Note: We do not use the parameters selected, dtype or oid as
-      // it is easier to use the tree directly as these do not refer to
-      // a jstree node
-      var tree_selected = datatree.get_selected(true);
-      omero_parade.omero_parade(tree_selected, datatree);
+      var dataTree = $.jstree.reference('#dataTree');
+      if (!dataTree) {
+        return;
+      }
+      omero_parade.omero_parade(dataTree);
     },
 
     // supported_obj_types: ['dataset', 'image', 'orphaned', 'tag']

--- a/omero_parade/templates/omero_parade/init.js.html
+++ b/omero_parade/templates/omero_parade/init.js.html
@@ -17,13 +17,11 @@ $(function() {
   // Start listening for Node Loading events on the tree...
   // If a node loads and it's selected, update_thumbs...
   let treeChanged = function(event, data){
-      if (data.node.state.selected) {
-          // update_thumbnails_panel(event, data);
-          var datatree = $.jstree.reference('#dataTree');
-          if (!datatree) return;
-          var tree_selected = datatree.get_selected(true);
-          omero_parade.omero_parade(tree_selected, datatree);
-      }
+      // update_thumbnails_panel(event, data);
+      var datatree = $.jstree.reference('#dataTree');
+      if (!datatree) return;
+      var tree_selected = datatree.get_selected(true);
+      omero_parade.omero_parade(tree_selected, datatree);
   }
 
   $("#dataTree").on('load_node.jstree', treeChanged)

--- a/package-lock.json
+++ b/package-lock.json
@@ -4681,8 +4681,7 @@
     "lodash": {
       "version": "4.17.5",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
-      "dev": true
+      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
     },
     "log-symbols": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "axios": "^0.17.1",
     "clusterfck": "^0.6.0",
+    "lodash": "^4.17.5",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-sparklines": "^1.7.0"

--- a/src/js/App.js
+++ b/src/js/App.js
@@ -22,53 +22,15 @@ import DataContainer from './dataLoader/DataContainer'
 
 class App extends Component {
 
-    static get PARENT_TYPES() {
-        return ["project",
-                "dataset",
-                "orphaned",
-                "tag",
-                "share",
-                "plate",
-                "acquisition"]
-    }
-
-    static createKey(parentNode, jstree) {
-        let key = parentNode? parentNode.id : undefined;
-        // Project + *open* Datasets as key identifies the content of the
-        // center panel.
-        if (parentNode && parentNode.type === "project") {
-            let atoms = parentNode.children.filter(
-                child => jstree.is_open(child)
-            );
-            atoms.unshift(key);
-            key = atoms.join("-");
-        }
-        // TODO: This would be where we would start the work handling
-        // Screen + *open* Plates as key
-        return key;
-    }
-
     constructor(props) {
         super(props);
     }
 
     render() {
-        // parentNode may be null if not suitable to display
-        let parentNode = this.props.parentNode;
-        let key = App.createKey(parentNode, this.props.jstree);
-        if (parentNode) {
-            this.previousParent = parentNode;
-            return (
-                <DataContainer
-                    key={key}
-                    parentNode={parentNode}
-                    jstree={this.props.jstree} />
-            )
-        }
-
         return (
-            <div></div>
-        );
+            <DataContainer
+                jstree={this.props.jstree} />
+        )
     }
 }
 

--- a/src/js/App.js
+++ b/src/js/App.js
@@ -22,101 +22,45 @@ import DataContainer from './dataLoader/DataContainer'
 
 class App extends Component {
 
+    static get PARENT_TYPES() {
+        return ["project",
+                "dataset",
+                "orphaned",
+                "tag",
+                "share",
+                "plate",
+                "acquisition"]
+    }
+
+    static createKey(parentNode, jstree) {
+        let key = parentNode? parentNode.id : undefined;
+        // Project + *open* Datasets as key identifies the content of the
+        // center panel.
+        if (parentNode && parentNode.type === "project") {
+            let atoms = parentNode.children.filter(
+                child => jstree.is_open(child)
+            );
+            atoms.unshift(key);
+            key = atoms.join("-");
+        }
+        // TODO: This would be where we would start the work handling
+        // Screen + *open* Plates as key
+        return key;
+    }
+
     constructor(props) {
         super(props);
-        this.parentTypes = ["project",
-                            "dataset",
-                            "orphaned",
-                            "tag",
-                            "share",
-                            "plate",
-                            "acquisition"]
-    }
-
-    renderNothing(selected) {
-        if (selected.length === 0) {
-            if (this.previousParent) {
-                return false;
-            }
-            return true;
-        }
-        var dtype = selected[0].type;
-        if (dtype === "image") {
-            return false;
-        }
-        // Don't support multiple selection of anything except images
-        if (selected.length > 1 && dtype !== "image") {
-            return true;
-        }
-        // Only some parent types supported
-        if (this.parentTypes.indexOf(dtype) === -1) {
-            return true;
-        }
-    }
-
-    componentWillReceiveProps(nextProps) {
-        // When props change...
-        // If nothing is selected AND the previous node is valid
-        // We continue to render that node (Dataset)
-        // if (nextProps.selected.length !== 0) {
-        //     delete(this.previousParent);
-        // }
-    }
-
-    getParentNode() {
-        // See http://will-moore.github.io/react-render-purely-props-and-state/
-
-        // If parentNode is a Dataset, but we're already showing Parent project
-        // we want to keep the same Project as parent
-
-        // OR if nothing is selected, we continue to render same parent
-
-        var selected = this.props.selected,
-            jstree = this.props.jstree;
-
-        // If unsupported objects selected, we return and show nothing
-        if (this.renderNothing(selected)) {
-            return;
-        }
-        
-        // If nothing selected, continue to show same parent / data
-        if (selected.length === 0 && this.previousParent) {
-            return this.previousParent;
-        }
-
-        // If a supported parent is selected, will only be 1
-        let parentNode;
-        var dtype = selected[0].type;
-        if (this.parentTypes.indexOf(dtype) > -1) {
-            parentNode = selected[0];
-        }
-
-        // Selected an image, we simply show it's container
-        if (dtype === "image") {
-            parentNode = jstree.get_node(jstree.get_parent(selected[0]));
-        }
-
-        // If we've got a Dataset within Project, return the Project
-        if (parentNode) {
-            let p = jstree.get_node(jstree.get_parent(parentNode));
-            if (p.type === "project") {
-                parentNode = p;
-            }
-        }
-        return parentNode;
     }
 
     render() {
         // parentNode may be null if not suitable to display
-        let parentNode = this.getParentNode();
-
+        let parentNode = this.props.parentNode;
+        let key = App.createKey(parentNode, this.props.jstree);
         if (parentNode) {
             this.previousParent = parentNode;
             return (
                 <DataContainer
-                    // key to force re-mounting when parent changes
-                    // This is node ID not Project or Dataset ID
-                    key={parentNode.id}
+                    key={key}
                     parentNode={parentNode}
                     jstree={this.props.jstree} />
             )

--- a/src/js/dataLoader/DataContainer.js
+++ b/src/js/dataLoader/DataContainer.js
@@ -38,10 +38,18 @@ class DataContainer extends React.Component {
 
     constructor(props) {
         super(props);
+        const jstree = this.props.jstree;
+        const treeSelectedNodes = jstree.get_selected(true);
+        const treeRootNodes = this.getRootNodes(treeSelectedNodes);
+        const effectiveRootNode =
+            this.getEffectiveRootNode(treeRootNodes, treeSelectedNodes);
+        const treeOpenNodes =
+            this.getOpenNodes(treeSelectedNodes, effectiveRootNode);
         this.state = {
-            treeOpenNodes: [],
-            treeRootNodes: [],
-            treeSelectedNodes: []
+            treeSelectedNodes: treeSelectedNodes,
+            treeRootNodes: treeRootNodes,
+            effectiveRootNode: effectiveRootNode,
+            treeOpenNodes: treeOpenNodes
         }
         $("#dataTree")
             .on('select_node.jstree', null, this, this.onJsTreeSelectNode)

--- a/src/js/dataLoader/DataContainer.js
+++ b/src/js/dataLoader/DataContainer.js
@@ -267,6 +267,7 @@ class DataContainer extends React.Component {
             return (
                 <DatasetContainer
                     jstree={jstree}
+                    treeSelectedNodes={this.state.treeSelectedNodes}
                     treeOpenNodes={this.state.treeOpenNodes}
                     effectiveRootNode={this.state.effectiveRootNode}
                     setSelectedImages={this.setSelectedImages}/>

--- a/src/js/dataLoader/DataContainer.js
+++ b/src/js/dataLoader/DataContainer.js
@@ -51,8 +51,9 @@ class DataContainer extends React.Component {
             effectiveRootNode: effectiveRootNode,
             treeOpenNodes: treeOpenNodes
         }
+        $("body")
+            .on('selection_change.ome', null, this, this.onSelectionChangeOme);
         $("#dataTree")
-            .on('select_node.jstree', null, this, this.onJsTreeSelectNode)
             .on('open_node.jstree', null, this, this.onJsTreeOpenCloseNode)
             .on('close_node.jstree', null, this, this.onJsTreeOpenCloseNode);
 
@@ -60,12 +61,12 @@ class DataContainer extends React.Component {
     }
 
     /**
-     * Called whenever a 'select_node.jstree' event is fired by the jsTree
-     * instance on the page.  This is a jQuery event handler so has slightly
-     * different semantics than if it were a React one.
+     * Called whenever a 'selection_change.ome' event is triggered on the page
+     * body.  This is a jQuery event handler so has slightly different
+     * semantics than if it were a React one.
      * @see https://www.jstree.com/api/#/?q=.jstree%20Event
      */
-    onJsTreeSelectNode(event, node, selected, triggerEvent) {
+    onSelectionChangeOme(event) {
         // As this is a jQuery integration, "this" will be the jQuery context
         // for the event handler.  We have passed the "DataContainer" along
         // as event data.
@@ -93,7 +94,7 @@ class DataContainer extends React.Component {
      * one.
      * @see https://www.jstree.com/api/#/?q=.jstree%20Event
      */
-    onJsTreeOpenCloseNode(event, node) {
+    onJsTreeOpenCloseNode(event, data) {
         // As this is a jQuery integration, "this" will be the jQuery context
         // for the event handler.  We have passed the "DataContainer" along
         // as event data.
@@ -205,17 +206,22 @@ class DataContainer extends React.Component {
         let jstree = this.props.jstree;
         if (jstree) {
             jstree.deselect_all();
-            if (imageIds.length === 0) return;
+            if (imageIds.length < 1) {
+                jstree.select_node(this.state.effectiveRootNode.id);
+            }
             let containerNode = OME.getTreeImageContainerBestGuess(imageIds[0]);
             let nodes = imageIds.map(iid => {
                 let containerNode = OME.getTreeImageContainerBestGuess(iid);
                 return jstree.locate_node('image-' + iid, containerNode)[0]
             });
-            jstree.select_node(nodes);
+            jstree.select_node(nodes, true);
             // we also focus the node, so that hotkey events come from the node
             if (nodes.length > 0) {
                 $("#" + nodes[0].id).children('.jstree-anchor').focus();
             }
+            $("#dataTree").trigger(
+                "selection_change.ome", jstree.get_selected(true).length
+            );
         }
     }
 

--- a/src/js/dataLoader/DataContainer.js
+++ b/src/js/dataLoader/DataContainer.js
@@ -169,7 +169,7 @@ class DataContainer extends React.Component {
             if (effectiveRootNode.type === "project") {
                 return effectiveRootNode.children.filter(
                     child => jstree.is_open(child)
-                );
+                ).map(v => jstree.get_node(v));
             }
             // When our root is a Dataset, it is what is open.
             if (effectiveRootNode.type === "dataset") {
@@ -259,7 +259,8 @@ class DataContainer extends React.Component {
             return (
                 <DatasetContainer
                     jstree={jstree}
-                    parentNode={effectiveRootNode}
+                    treeOpenNodes={this.state.treeOpenNodes}
+                    effectiveRootNode={this.state.effectiveRootNode}
                     setSelectedImages={this.setSelectedImages}/>
             )
         }

--- a/src/js/dataLoader/DataContainer.js
+++ b/src/js/dataLoader/DataContainer.js
@@ -47,48 +47,69 @@ class DataContainer extends React.Component {
     }
 
     render() {
+        var jstree = this.props.jstree;
         var parentNode = this.props.parentNode;
+        var parentNodeId = parentNode.data.id;
 
         // If not loaded, show nothing (don't know how many children plate will have)
         if (!parentNode.state.loaded) {
             return (<h2 className="iconTable">Loading...</h2>);
         }
-
         // If plate has > 1 run, show nothing
         if (parentNode.type === "plate" && parentNode.children.length > 1) {
             return (<h2 className="iconTable">Select Run</h2>);
         }
-        // key identifies the content of center panel. Plate or Run
+        // If Project has no open Datasets, offer to open them all
+        if (parentNode.type === "project") {
+            let openChildren = parentNode.children.filter(
+                child => jstree.is_open(child)
+            );
+            if (openChildren.length < 1) {
+                return (
+                    <div className="parade_openAll">
+                        <h1>No open Datasets</h1>
+                        <button
+                            onClick={() => {
+                                this.props.jstree.open_all(
+                                    this.props.parentNode.id
+                                )
+                            }}>
+                            Open All
+                        </button>
+                    </div>
+                );
+            }
+        }
+
+        // Plate or Run as key identifies the content of center panel.
         var key = parentNode.id;
         if (parentNode.type === "plate" && parentNode.children.length === 1) {
             // Children is list of node-ids
             key = parentNode.children[0];
         }
+
         // We pass key to <FieldsLoader> so that if key doesn't change,
         // Plate won't mount (load data) again
-        var jstree = this.props.jstree;
-        var parentId = parentNode.data.id;
-        var dtype = parentNode.type;
-
-        let rv = (<div>OOps {dtype}</div>);
-        if (dtype == "plate" || dtype == "aquisition") {
-            if (dtype == "acquisition") {
-                parentId = jstree.get_node(jstree.get_parent(parentNode)).data.id;
+        let rv = (<div>OOps {parentNode.type}</div>);
+        if (parentNode.type == "plate" || parentNode.type == "aquisition") {
+            if (parentNode.type == "acquisition") {
+                parentNodeId = jstree.get_node(jstree.get_parent(parentNode)).data.id;
             }
 
             rv = (
                 <FieldsLoader
-                    plateId={parentId}
+                    plateId={parentNodeId}
                     parentNode={parentNode}
                     key={key}/>
             )
         }
-        if (dtype === "dataset" || dtype === "project") {
+        if (parentNode.type === "dataset" || parentNode.type === "project") {
             rv = (
                 <DatasetContainer
                     jstree={jstree}
                     parentNode={parentNode}
-                    setSelectedImages={this.setSelectedImages}/>
+                    setSelectedImages={this.setSelectedImages}
+                    key={key}/>
             )
         }
         return rv;

--- a/src/js/dataLoader/DataContainer.js
+++ b/src/js/dataLoader/DataContainer.js
@@ -23,9 +23,174 @@ import DatasetContainer from './datasetLoader/DatasetContainer';
 
 class DataContainer extends React.Component {
 
+    static get ROOT_NODE_TYPES() {
+        return [
+            "project",
+            "dataset",
+            "orphaned",
+            "tag",
+            "share",
+            "screen",
+            "plate",
+            "acquisition"
+        ]
+    }
+
     constructor(props) {
         super(props);
+        this.state = {
+            treeOpenNodes: [],
+            treeRootNodes: [],
+            treeSelectedNodes: []
+        }
+        $("#dataTree")
+            .on('select_node.jstree', null, this, this.onJsTreeSelectNode)
+            .on('open_node.jstree', null, this, this.onJsTreeOpenCloseNode)
+            .on('close_node.jstree', null, this, this.onJsTreeOpenCloseNode);
+
         this.setSelectedImages = this.setSelectedImages.bind(this);
+    }
+
+    /**
+     * Called whenever a 'select_node.jstree' event is fired by the jsTree
+     * instance on the page.  This is a jQuery event handler so has slightly
+     * different semantics than if it were a React one.
+     * @see https://www.jstree.com/api/#/?q=.jstree%20Event
+     */
+    onJsTreeSelectNode(event, node, selected, triggerEvent) {
+        // As this is a jQuery integration, "this" will be the jQuery context
+        // for the event handler.  We have passed the "DataContainer" along
+        // as event data.
+        const _this = event.data;
+        const jstree = _this.props.jstree;
+        const treeSelectedNodes = jstree.get_selected(true);
+        const treeRootNodes = _this.getRootNodes(treeSelectedNodes);
+        const effectiveRootNode =
+            _this.getEffectiveRootNode(treeRootNodes, treeSelectedNodes);
+        const treeOpenNodes =
+            _this.getOpenNodes(treeSelectedNodes, effectiveRootNode);
+
+        _this.setState({
+            treeSelectedNodes: treeSelectedNodes,
+            treeRootNodes: treeRootNodes,
+            effectiveRootNode: effectiveRootNode,
+            treeOpenNodes: treeOpenNodes
+        });
+    }
+
+    /**
+     * Called whenever a 'open_node.jstree' or 'close_node.jstree' event is
+     * fired by the jsTree instance on the page.  This is a jQuery event
+     * handler so has slightly different semantics than if it were a React
+     * one.
+     * @see https://www.jstree.com/api/#/?q=.jstree%20Event
+     */
+    onJsTreeOpenCloseNode(event, node) {
+        // As this is a jQuery integration, "this" will be the jQuery context
+        // for the event handler.  We have passed the "DataContainer" along
+        // as event data.
+        const _this = event.data;
+        _this.setState((prevState, props) => {
+            return {
+                treeOpenNodes: _this.getOpenNodes(
+                    prevState.treeSelectedNodes, prevState.effectiveRootNode
+                )
+            }
+        })
+    }
+
+    /**
+     * From a set of selected jsTree nodes return a corresponding array of
+     * root nodes.
+     */
+    getRootNodes(selectedNodes) {
+        const jstree = this.props.jstree;
+        return selectedNodes.map(v => {
+            let treeRootNode = v;
+            let parentNode = treeRootNode;
+            while (parentNode.type !== "experimenter") {
+                treeRootNode = parentNode;
+                parentNode = jstree.get_node(
+                    jstree.get_parent(treeRootNode.id)
+                );
+            }
+            return treeRootNode;
+        });
+    }
+
+    /**
+     * From a set of selected and root jsTree nodes return the single
+     * effective root node.  The set of supported root node types is
+     * defined by <code>ROOT_NODE_TYPES</code>, all selected nodes must
+     * be of the same type, and either one node must be selected or
+     * <strong>only</strong> images must be selected.
+     *
+     * If any of these conditions are not met the effective root node is
+     * undefined.
+     */
+    getEffectiveRootNode(rootNodes, selectedNodes) {
+        if (rootNodes.length < 1) {
+            return;
+        }
+        const effectiveRoot = rootNodes[0];
+
+        // There are a limited set of supported root node types
+        if (!DataContainer.ROOT_NODE_TYPES.includes(effectiveRoot.type)) {
+            return;
+        }
+        // The root node for all selected nodes must be the same
+        for (let rootNode of rootNodes) {
+            if (effectiveRoot.id !== rootNode.id) {
+                return;
+            }
+        }
+        // There must be either one selected node or all nodes must be
+        // of "image" type
+        if (selectedNodes.length > 1) {
+            for (let selectedNode of selectedNodes) {
+                if (selectedNode.type !== "image") {
+                    return;
+                }
+            }
+        }
+
+        return effectiveRoot;
+    }
+
+    /**
+     * From a set of selected and effective root jsTree nodes return the
+     * array of open jsTree nodes under that effective root.
+     */
+    getOpenNodes(treeSelectedNodes, effectiveRootNode) {
+        const jstree = this.props.jstree;
+        if (effectiveRootNode) {
+            // When our root is a Project, the open nodes are all its
+            // children (Datasets) which are open.
+            if (effectiveRootNode.type === "project") {
+                return effectiveRootNode.children.filter(
+                    child => jstree.is_open(child)
+                );
+            }
+            // When our root is a Dataset, it is what is open.
+            if (effectiveRootNode.type === "dataset") {
+                return [effectiveRootNode];
+            }
+            // When our root is a Screen or a Plate the effective root will
+            // only be defined if a single Screen, Plate or PlateAcquisition
+            // is selected.
+            if (["screen", "plate"].includes(effectiveRootNode.type)) {
+                let selectedNode = treeSelectedNodes[0];
+                if (selectedNode.type === "plate") {
+                    return [selectedNode];
+                }
+                if (selectedNode.type === "acquisition") {
+                    return [jstree.get_node(
+                        jstree.get_parent(selectedNode.id)
+                    )];
+                }
+            }
+        }
+        return [];
     }
 
     setSelectedImages(imageIds) {
@@ -47,31 +212,30 @@ class DataContainer extends React.Component {
     }
 
     render() {
-        var jstree = this.props.jstree;
-        var parentNode = this.props.parentNode;
-        var parentNodeId = parentNode.data.id;
+        const jstree = this.props.jstree;
+        const effectiveRootNode = this.state.effectiveRootNode;
 
-        // If not loaded, show nothing (don't know how many children plate will have)
-        if (!parentNode.state.loaded) {
-            return (<h2 className="iconTable">Loading...</h2>);
+        // If we have no effective root node, show nothing
+        if (!effectiveRootNode) {
+            return (
+                <div></div>
+            );
         }
         // If plate has > 1 run, show nothing
-        if (parentNode.type === "plate" && parentNode.children.length > 1) {
+        if (effectiveRootNode.type === "plate"
+                && effectiveRootNode.children.length > 1) {
             return (<h2 className="iconTable">Select Run</h2>);
         }
         // If Project has no open Datasets, offer to open them all
-        if (parentNode.type === "project") {
-            let openChildren = parentNode.children.filter(
-                child => jstree.is_open(child)
-            );
-            if (openChildren.length < 1) {
+        if (effectiveRootNode.type === "project") {
+            if (this.state.treeOpenNodes.length < 1) {
                 return (
                     <div className="parade_openAll">
                         <h1>No open Datasets</h1>
                         <button
                             onClick={() => {
-                                this.props.jstree.open_all(
-                                    this.props.parentNode.id
+                                jstree.open_all(
+                                    effectiveRootNode.id
                                 )
                             }}>
                             Open All
@@ -81,38 +245,25 @@ class DataContainer extends React.Component {
             }
         }
 
-        // Plate or Run as key identifies the content of center panel.
-        var key = parentNode.id;
-        if (parentNode.type === "plate" && parentNode.children.length === 1) {
-            // Children is list of node-ids
-            key = parentNode.children[0];
-        }
-
-        // We pass key to <FieldsLoader> so that if key doesn't change,
-        // Plate won't mount (load data) again
-        let rv = (<div>OOps {parentNode.type}</div>);
-        if (parentNode.type == "plate" || parentNode.type == "aquisition") {
-            if (parentNode.type == "acquisition") {
-                parentNodeId = jstree.get_node(jstree.get_parent(parentNode)).data.id;
-            }
-
-            rv = (
+        if (effectiveRootNode.type === "screen"
+                || effectiveRootNode.type === "plate") {
+            return (
                 <FieldsLoader
-                    plateId={parentNodeId}
-                    parentNode={parentNode}
-                    key={key}/>
+                    treeSelectedNodes={this.state.treeSelectedNodes}
+                    treeOpenNodes={this.state.treeOpenNodes}
+                    effectiveRootNode={this.state.effectiveRootNode}/>
             )
         }
-        if (parentNode.type === "dataset" || parentNode.type === "project") {
-            rv = (
+        if (effectiveRootNode.type === "project"
+                || effectiveRootNode.type === "dataset") {
+            return (
                 <DatasetContainer
                     jstree={jstree}
-                    parentNode={parentNode}
-                    setSelectedImages={this.setSelectedImages}
-                    key={key}/>
+                    parentNode={effectiveRootNode}
+                    setSelectedImages={this.setSelectedImages}/>
             )
         }
-        return rv;
+        return (<div>Oops {effectiveRootNode.type}</div>);
     }
 }
 

--- a/src/js/dataLoader/datasetLoader/DatasetContainer.js
+++ b/src/js/dataLoader/datasetLoader/DatasetContainer.js
@@ -56,7 +56,7 @@ class DatasetContainer extends React.Component{
             .map(i => i.data.obj.filesetId);
         // Go through all images, adding fs-selection flag if in selected
         // fileset
-        if (selectedFilesetIds.length < 1) {
+        if (selectedFilesetIds.length > 0) {
             for (let imageJson of imagesJson) {
                 const filesetId = imageJson.data.obj.filesetId;
                 if (selectedFilesetIds.includes(filesetId)) {

--- a/src/js/dataLoader/datasetLoader/DatasetContainer.js
+++ b/src/js/dataLoader/datasetLoader/DatasetContainer.js
@@ -24,20 +24,18 @@ class DatasetContainer extends React.Component{
 
     constructor(props) {
         super(props);
-        this.marshalNode = this.marshalNode.bind(this);
-        this.getImageNodes = this.getImageNodes.bind(this);
     }
 
     marshalNode(node) {
-        var parentNode = this.props.parentNode;
-        var dateFormatOptions = {
+        const effectiveRootNode = this.props.effectiveRootNode;
+        const dateFormatOptions = {
             weekday: "short", year: "numeric", month: "short",
             day: "numeric", hour: "2-digit", minute: "2-digit"
         };
-        var d = node.data.obj.date || node.data.obj.acqDate;
-        var date = new Date(d);
+        const d = node.data.obj.date || node.data.obj.acqDate;
+        let date = new Date(d);
         date = date.toLocaleTimeString(undefined, dateFormatOptions);
-        var iData = {'id': node.data.obj.id,
+        let iData = {'id': node.data.obj.id,
             'name': node.text,
             'data': JSON.parse(JSON.stringify(node.data)),
             'selected': node.state.selected,
@@ -47,7 +45,7 @@ class DatasetContainer extends React.Component{
             'datasetId': node.datasetId,
         };
         // If image is in share and share is not owned by user...
-        if (node.data.obj.shareId && !parentNode.data.obj.isOwned) {
+        if (node.data.obj.shareId && !effectiveRootNode.data.obj.isOwned) {
             // share ID will be needed to open image viewer
             iData.shareId = node.data.obj.shareId;
         }
@@ -55,42 +53,30 @@ class DatasetContainer extends React.Component{
     }
 
     getImageNodes() {
-        // If we have a Dataset parent, simply get child images.
-        // If we have a Project, iterate through each Dataset to get images.
-        let jstree = this.props.jstree;
-        let dtype = this.props.parentNode.type;
-        let imgNodes = [];
-        if (dtype === "dataset") {
-            imgNodes = this.props.parentNode.children.map(ch => jstree.get_node(ch));
-        } else if (dtype === "project") {
-            imgNodes = this.props.parentNode.children.reduce((prev, dataset) => {
-                let ds_node = jstree.get_node(dataset);
-                let ds_name = ds_node.text;
-                let ds_id = ds_node.data.id;
-                // console.log(ds_id, ds_node);
-                // will get empty array if Dataset node is not loaded
-                // Only include images if Dataset expanded
-                if (ds_node.state.opened) {
-                    let images = ds_node.children.map(ch => jstree.get_node(ch));
-                    // add datasetName to each image
-                    images = images.map(i => Object.assign({}, i,
-                        {datasetName: ds_name, datasetId: ds_id}))
-                    prev = prev.concat(images);
+        const jstree = this.props.jstree;
+        let imageNodes = [];
+        for (let openNode of this.props.treeOpenNodes) {
+            for (let childNode of openNode.children) {
+                childNode = jstree.get_node(childNode);
+                if (childNode.type !== "image") {
+                    continue;
                 }
-                return prev;
-            }, []);
+                if (openNode.type === "dataset") {
+                    childNode.datasetName = openNode.text;
+                    childNode.datasetId = openNode.data.id;
+                }
+                imageNodes.push(childNode);
+            }
         }
-
-        // Ignore non-images under tags or 'deleted' under shares
-        imgNodes = imgNodes.filter(node => node.type === "image");
-        return imgNodes;
+        return imageNodes;
     }
 
     render() {
-        var imgNodes = this.getImageNodes();
+        const effectiveRootNode = this.props.effectiveRootNode;
+        const imgNodes = this.getImageNodes();
 
         // Convert jsTree nodes into json for template
-        let imgJson = imgNodes.map(this.marshalNode);
+        let imgJson = imgNodes.map(node => this.marshalNode(node));
 
         // Get selected filesets...
         let selFileSets = imgJson.filter(i => i.selected).map(i => i.data.obj.filesetId);
@@ -104,8 +90,8 @@ class DatasetContainer extends React.Component{
         }
 
         return (<FilterHub
-                parentType={this.props.parentNode.type}
-                parentId={this.props.parentNode.data.obj.id}
+                parentType={effectiveRootNode.type}
+                parentId={effectiveRootNode.data.obj.id}
                 setSelectedImages = {this.props.setSelectedImages}
                 images={imgJson}
             />)

--- a/src/js/dataLoader/plateLoader/PlateLoader.js
+++ b/src/js/dataLoader/plateLoader/PlateLoader.js
@@ -29,23 +29,38 @@ class PlateLoader extends React.Component {
         }
     }
 
-    componentDidMount() {
-        var plateId = this.props.plateId,
+    loadData() {
+        let plateId = this.props.plateId,
             fieldId = this.props.fieldId;
 
-        if (fieldId === undefined) return;
+        if (fieldId === undefined) {
+            return;
+        }
 
-        var url = "/webgateway/plate/" + plateId + "/" + fieldId + "/";
+        const url = "/webgateway/plate/" + plateId + "/" + fieldId + "/";
         $.ajax({
             url: url,
             dataType: 'json',
             cache: false,
-            success: data => {
+            success: v => {
                 this.setState({
-                    data: data,
+                    data: v,
                 });
             }
         });
+    }
+
+    componentDidMount() {
+        this.loadData();
+    }
+
+    componentDidUpdate(prevProps, prevState, snapshot) {
+        // Pattern to update based on discussion on this RFC issue:
+        //  * https://github.com/reactjs/rfcs/issues/26
+        if (prevProps.plateId !== this.props.plateId
+                || prevProps.fieldId !== this.props.fieldId) {
+            this.loadData();
+        }
     }
 
     render() {

--- a/src/js/filter/ParadeFilter.js
+++ b/src/js/filter/ParadeFilter.js
@@ -51,6 +51,9 @@ class ParadeFilter extends React.Component {
             url += '?' + this.props.images.map(i => 'image=' + i.id).join('&');
         }
         $.getJSON(url, function(data){
+            if (!data.f) {
+                return;
+            }
             // Response has filter function - Needs eval()
             var f = eval(data.f);
             // Get current values - set state to parent

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -75,16 +75,9 @@ function getParentNode(selected, jstree) {
 }
 
 // Export a function for rendering omero_parade as a centre panel plugin
-function omero_parade(selected, jstree) {
-    let parentNode = getParentNode(selected, jstree);
-    let key = App.createKey(parentNode, jstree);
-
+function omero_parade(jstree) {
     ReactDOM.render(
-        <App
-            key={key}
-            selected={selected}
-            parentNode={parentNode}
-            jstree={jstree} />,
+        <App jstree={jstree} />,
         document.getElementById('omero_parade')
     );
 }

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -21,22 +21,80 @@ import ReactDOM from 'react-dom';
 import App from './App';
 import SearchApp from './search/SearchApp';
 
+function renderNothing(selected) {
+    if (selected.length === 0) {
+        return true;
+    }
+    let dtype = selected[0].type;
+    if (dtype === "image") {
+        return false;
+    }
+    // Don't support multiple selection of anything except images
+    if (selected.length > 1 && dtype !== "image") {
+        return true;
+    }
+    // Only some parent types supported
+    if (!App.PARENT_TYPES.includes(dtype)) {
+        return true;
+    }
+}
+
+function getParentNode(selected, jstree) {
+    // See http://will-moore.github.io/react-render-purely-props-and-state/
+
+    // If parentNode is a Dataset, but we're already showing Parent project
+    // we want to keep the same Project as parent
+
+    // OR if nothing is selected, we continue to render same parent
+
+    // If unsupported objects selected, we return and show nothing
+    if (renderNothing(selected)) {
+        return;
+    }
+
+    // If a supported parent is selected, will only be 1
+    let parentNode;
+    let dtype = selected[0].type;
+    if (App.PARENT_TYPES.includes(dtype)) {
+        parentNode = selected[0];
+    }
+
+    // Selected an image, we simply show it's container
+    if (dtype === "image") {
+        parentNode = jstree.get_node(jstree.get_parent(selected[0]));
+    }
+
+    // If we've got a Dataset within Project, return the Project
+    if (parentNode) {
+        let p = jstree.get_node(jstree.get_parent(parentNode));
+        if (p.type === "project") {
+            parentNode = p;
+        }
+    }
+    return parentNode;
+}
+
 // Export a function for rendering omero_parade as a centre panel plugin
 function omero_parade(selected, jstree) {
-  ReactDOM.render(
-    <App
-        selected={selected}
-        jstree={jstree} />,
-    document.getElementById('omero_parade')
-  );
+    let parentNode = getParentNode(selected, jstree);
+    let key = App.createKey(parentNode, jstree);
+
+    ReactDOM.render(
+        <App
+            key={key}
+            selected={selected}
+            parentNode={parentNode}
+            jstree={jstree} />,
+        document.getElementById('omero_parade')
+    );
 }
 
 // Full page app
 function full_page_app(element_id) {
-  ReactDOM.render(
-    <SearchApp />,
-    document.getElementById(element_id)
-  );
+    ReactDOM.render(
+        <SearchApp />,
+        document.getElementById(element_id)
+    );
 }
 
 export { omero_parade, full_page_app }

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -21,59 +21,6 @@ import ReactDOM from 'react-dom';
 import App from './App';
 import SearchApp from './search/SearchApp';
 
-function renderNothing(selected) {
-    if (selected.length === 0) {
-        return true;
-    }
-    let dtype = selected[0].type;
-    if (dtype === "image") {
-        return false;
-    }
-    // Don't support multiple selection of anything except images
-    if (selected.length > 1 && dtype !== "image") {
-        return true;
-    }
-    // Only some parent types supported
-    if (!App.PARENT_TYPES.includes(dtype)) {
-        return true;
-    }
-}
-
-function getParentNode(selected, jstree) {
-    // See http://will-moore.github.io/react-render-purely-props-and-state/
-
-    // If parentNode is a Dataset, but we're already showing Parent project
-    // we want to keep the same Project as parent
-
-    // OR if nothing is selected, we continue to render same parent
-
-    // If unsupported objects selected, we return and show nothing
-    if (renderNothing(selected)) {
-        return;
-    }
-
-    // If a supported parent is selected, will only be 1
-    let parentNode;
-    let dtype = selected[0].type;
-    if (App.PARENT_TYPES.includes(dtype)) {
-        parentNode = selected[0];
-    }
-
-    // Selected an image, we simply show it's container
-    if (dtype === "image") {
-        parentNode = jstree.get_node(jstree.get_parent(selected[0]));
-    }
-
-    // If we've got a Dataset within Project, return the Project
-    if (parentNode) {
-        let p = jstree.get_node(jstree.get_parent(parentNode));
-        if (p.type === "project") {
-            parentNode = p;
-        }
-    }
-    return parentNode;
-}
-
 // Export a function for rendering omero_parade as a centre panel plugin
 function omero_parade(jstree) {
     ReactDOM.render(


### PR DESCRIPTION
Add the capability of opening all Datasets in a Project if they are all closed
and change the semantics so that expanding or collapsing a node,
not selecting it, affects what is shown by Parade.

In order to provide functionality to open all Dataset children for a
selected Project the component hierarchy needs to reflect what nodes
of the jsTree that are *open* rather than just those that are
*selected*.  This PR contains refactoring to all jsTree node handling,
initial state, and resulting subcomponent usage so as to provide the
display components with reliable and thorough context under which
to operate.

The stage is further set to enable the same type of logic for Screens
once we are ready.

Note that the changes in this PR bind Parade to the base level
`selection_change.ome` event.
