### PR TITLE
Handle scenarios where we initially have transient state

### DIFF
--- a/src/js/dataLoader/datasetLoader/DatasetContainer.js
+++ b/src/js/dataLoader/datasetLoader/DatasetContainer.js
@@ -25,8 +25,21 @@ class DatasetContainer extends React.Component{
 
     constructor(props) {
         super(props);
+        let transientState = false;
+        for (let openNode of props.treeOpenNodes) {
+            if (props.jstree.is_loading(openNode)) {
+                // State is transient, mounting may have been triggered
+                // by a selection event on a jsTree node that has not yet
+                // been loaded.  We will be notified of steady state by a
+                // later event, at which time componentDidUpdate() will be
+                // called.
+                transientState = true;
+                break;
+            }
+        }
         this.state = {
-            imagesJson: this.createImagesJson()
+            imagesJson: this.createImagesJson(),
+            transientState: transientState
         }
     }
 
@@ -36,10 +49,12 @@ class DatasetContainer extends React.Component{
         const treeSelectedNodes = this.props.treeSelectedNodes.map(v => v.id);
         const prevTreeSelectedNodes =
             prevProps.treeSelectedNodes.map(v => v.id);
-        if (!_.isEqual(treeOpenNodes, prevTreeOpenNodes)
+        if (this.state.transientState
+                || !_.isEqual(treeOpenNodes, prevTreeOpenNodes)
                 || !_.isEqual(treeSelectedNodes, prevTreeSelectedNodes)) {
             this.setState({
-                imagesJson: this.createImagesJson()
+                imagesJson: this.createImagesJson(),
+                transientState: false
             });
         }
     }


### PR DESCRIPTION
Under certain conditions when we recieve a "selection_change.ome" event
the jsTree has not yet been loaded.  This seems to be isolated to
scenarios where the effective root node is a Dataset but it is certainly
possible that it is happening during elsewhere.

This ensures that when the resultant component update happens that the
transient state is noticed and the image JSON is brought in sync.