### PR TITLE
Filter roi count zero

### DIFF
--- a/omero_parade/data_providers.py
+++ b/omero_parade/data_providers.py
@@ -60,6 +60,9 @@ def get_data(request, data_name, conn):
                 "where roi.image.id in (:ids) group by roi.image"
         p = query_service.projection(query, params, conn.SERVICE_OPTS)
         roi_counts = {}
+        for i in img_ids:
+            # Add placeholder 0 for all images
+            roi_counts[i] = 0
         for i in p:
             roi_counts[i[0].val] = i[1].val
         return roi_counts

--- a/omero_parade/omero_filters.py
+++ b/omero_parade/omero_filters.py
@@ -55,6 +55,9 @@ def get_script(request, script_name, conn):
                 "where roi.image.id in (:ids) group by roi.image"
         p = query_service.projection(query, params, conn.SERVICE_OPTS)
         roi_counts = {}
+        for i in img_ids:
+            # Add placeholder 0 for all images
+            roi_counts[i] = 0
         for i in p:
             roi_counts[i[0].val] = i[1].val
         values = roi_counts.values()


### PR DESCRIPTION
In preparing metadata workshop, wanting to know which images have 0 ROIs, I found that filtering for ```ROI_count < 1``` didn't show any results because no data exist if no ROIs are found.

Also, loading table data ROI_count for a Dataset where NO images have any ROIs causes an error on ```numpy.amin(values)``` in views.py because values is an empty list.

Both these can be fixed by adding ```data[image_id] = 0``` for images with no ROIs.
This also improves the appearance of the ROI_count column in the table since we don't have empty table cells.

To test:
 - Filter a Dataset of Images for ```ROI_Count < 1```.
 - Add ```ROI_Count``` column to the table layout and see that 0 appears for images with no ROIs.