### PR TITLE
parseInt() values for Table filter

### DIFF
--- a/src/js/filter/FilterInput.js
+++ b/src/js/filter/FilterInput.js
@@ -46,6 +46,8 @@ class FilterInput extends React.Component {
             return value;
         }
         let padding = parseInt(max).toString().length - parseInt(value).toString().length;
+        // In case we just switched Table column and old value > new max
+        padding = Math.max(0, padding);
         return "\u2007".repeat(padding) + value;
     }
 

--- a/src/js/filter/FilterInput.js
+++ b/src/js/filter/FilterInput.js
@@ -33,14 +33,19 @@ class FilterInput extends React.Component {
     /** Returns a figure space padded version of the current value. */
     getPaddedValue() {
         let max = this.props.max;
-        let value = parseInt(this.props.value);
+        let value = parseFloat(this.props.value);
         if (isNaN(value)) {
             value = this.props.value;
+        } else if (parseInt(max) === max) {
+            // If max is Integer, we format value as integer
+            value = parseInt(value)
+        } else {
+            value = value.toFixed(2)
         }
         if (max == undefined) {
             return value;
         }
-        let padding = max.toString().length - value.toString().length;
+        let padding = parseInt(max).toString().length - parseInt(value).toString().length;
         return "\u2007".repeat(padding) + value;
     }
 

--- a/src/js/filter/FilterInput.js
+++ b/src/js/filter/FilterInput.js
@@ -33,7 +33,10 @@ class FilterInput extends React.Component {
     /** Returns a figure space padded version of the current value. */
     getPaddedValue() {
         let max = this.props.max;
-        let value = this.props.value;
+        let value = parseInt(this.props.value);
+        if (isNaN(value)) {
+            value = this.props.value;
+        }
         if (max == undefined) {
             return value;
         }

--- a/src/js/filter/ParadeFilter.js
+++ b/src/js/filter/ParadeFilter.js
@@ -87,13 +87,26 @@ class ParadeFilter extends React.Component {
         }
         if (filterParam.minima) {
             this.setState({
-                minimum: parseInt(filterParam.minima[value])
+                minimum: filterParam.minima[value]
             });
         }
         if (filterParam.maxima) {
             this.setState({
-                maximum: parseInt(filterParam.maxima[value])
+                maximum: filterParam.maxima[value]
             });
+        }
+    }
+
+    // Formats float to 2 places. Otherwise returns value.
+    formatNumber(value) {
+        let num = parseFloat(value);
+        if (isNaN(num)) {
+            return value
+        }
+        if (parseInt(num) === num) {
+           return value
+        } else {
+            return num.toFixed(2)
         }
     }
 
@@ -114,11 +127,15 @@ class ParadeFilter extends React.Component {
                     })}
                 </div>
                 <div className="sparkline">
-                    <span className="minimum">{this.state.minimum}</span>
+                    <span className="minimum">
+                        {this.formatNumber(this.state.minimum)}
+                    </span>
                     <Sparklines data={this.state.histogram}>
                         <SparklinesBars />
                     </Sparklines>
-                    <span className="maximum">{this.state.maximum}</span>
+                    <span className="maximum">
+                        {this.formatNumber(this.state.maximum)}
+                    </span>
                 </div>
                 <button
                     className="parade_removeFilter"

--- a/src/js/filter/ParadeFilter.js
+++ b/src/js/filter/ParadeFilter.js
@@ -87,12 +87,12 @@ class ParadeFilter extends React.Component {
         }
         if (filterParam.minima) {
             this.setState({
-                minimum: filterParam.minima[value]
+                minimum: parseInt(filterParam.minima[value])
             });
         }
         if (filterParam.maxima) {
             this.setState({
-                maximum: filterParam.maxima[value]
+                maximum: parseInt(filterParam.maxima[value])
             });
         }
     }


### PR DESCRIPTION
Tables with float values don't render very nicely.

<img width="729" alt="screen shot 2018-05-05 at 06 18 01" src="https://user-images.githubusercontent.com/900055/39667918-a33b3030-50b8-11e8-8a06-084d9311adb7.png">

Trying to improve it with ```parseInt()``` when setting min, max and in getPaddedValue().

To test:
 - user-3 http://web-dev-merge.openmicroscopy.org/webclient/?show=project-4501
 - Add Filter -> Table
 - Test Integer and Float columns e.g. points columns are Integers and intensity are floats.