### PR TITLE
app config

### DIFF
--- a/omero_parade/__init__.py
+++ b/omero_parade/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'omero_parade.apps.ParadeAppConfig'

--- a/omero_parade/apps.py
+++ b/omero_parade/apps.py
@@ -19,6 +19,7 @@
 
 from django.apps import AppConfig
 
+
 class ParadeAppConfig(AppConfig):
     name = "omero_parade"
     label = "parade"

--- a/omero_parade/apps.py
+++ b/omero_parade/apps.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2018 University of Dundee.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from django.apps import AppConfig
+
+class ParadeAppConfig(AppConfig):
+    name = "omero_parade"
+    label = "parade"


### PR DESCRIPTION
In sticking with the pattern of our other apps, this adds an app config so that all parade urls are ```/parade/``` instead of ```/omero_parade/```.

Although users don't yet see any parade urls in the browser (except for the home-page in https://github.com/ome/omero-parade/pull/7) it makes sense to get this right now so URLs don't change when we add this later.

cc @chris-allan 

To test:
 - Go to ```/parade/``` and you should see the home page (matches screenshot in #7).
 - Everything else should continue to work as before.