### PR TITLE
Numpy 1.7 serializable

### DIFF
--- a/omero_parade/table_filters/omero_filters.py
+++ b/omero_parade/table_filters/omero_filters.py
@@ -69,20 +69,20 @@ def get_script(request, script_name, conn):
         for name, col in zip(column_names, col_data):
             values = numpy.array(col.values)
             # key is column Name, values are list of col_data
-            table_data[name] = list(values)
+            table_data[name] = values.tolist()
 
             if not isinstance(col, (DoubleColumn, LongColumn)):
                 continue
 
-            minima[name] = numpy.amin(values)
-            maxima[name] = numpy.amax(values)
+            minima[name] = numpy.amin(values).item()
+            maxima[name] = numpy.amax(values).item()
             bins = 10
             if NUMPY_GT_1_11_0:
                 # numpy.histogram() only supports bin calculation
                 # from 1.11.0 onwards
                 bins = 'auto'
             histogram, bin_edges = numpy.histogram(values, bins=bins)
-            histograms[name] = list(histogram)
+            histograms[name] = histogram.tolist()
 
         # Return a JS function that will be passed an object
         # e.g. {'type': 'Image', 'id': 1}

--- a/omero_parade/views.py
+++ b/omero_parade/views.py
@@ -176,9 +176,9 @@ def get_data(request, data_name, conn=None, **kwargs):
                     histogram, bin_edges = numpy.histogram(values, bins=bins)
                     return JsonResponse({
                         'data': data,
-                        'min': numpy.amin(values),
-                        'max': numpy.amax(values),
-                        'histogram': list(histogram)
+                        'min': numpy.amin(values).item(),
+                        'max': numpy.amax(values).item(),
+                        'histogram': histogram.tolist()
                     })
         except ImportError:
             pass


### PR DESCRIPTION
Following on from investigation in https://github.com/ome/omero-parade/pull/28, this uses numpy .item() and .tolist() to give values that are JSON serializable, even with numpy 1.7.

To test:
 - Filter images by ```Table``` data.
 - Load any Table data to display in columns - E.g. ```ROI_count``` or ```Table_*``` data.