### PR TITLE
Search page fixes

### DIFF
--- a/omero_parade/data_providers.py
+++ b/omero_parade/data_providers.py
@@ -42,6 +42,8 @@ def get_data(request, data_name, conn):
         img_ids = [i.id for i in objects]
     elif plate_id and field_id:
         img_ids = get_image_ids(conn, plate_id, field_id)
+    else:
+        img_ids = request.GET.getlist('image')
     query_service = conn.getQueryService()
 
     if data_name == "ROI_stats_max_size":

--- a/omero_parade/views.py
+++ b/omero_parade/views.py
@@ -36,7 +36,8 @@ if LooseVersion(numpy.__version__) > LooseVersion('1.11.0'):
     NUMPY_GT_1_11_0 = True
 
 
-def index(request):
+@login_required()
+def index(request, **kwargs):
     return render(request, "omero_parade/index.html", {})
 
 


### PR DESCRIPTION
This fixes loading of column data in the ```/parade/``` search page.
Also adds ```@login_required``` to the search page to redirect to login screen if not logged in.

To test:
 - Go to ```/parade/```. If not logged in (AND Public user is *not* enabled) you should get redirected to login screen.
 - Search for something that returns a bunch of images (not more than ~4000) displayed in centre panel then choose table layout and ```Add table data... > ROI_Count``` (or Size T) to show the data in column (requires https://github.com/ome/omero-parade/pull/32/commits/92590108ed2f30498711d698d5910125f1fab8f6) from #32

NB: As discussed, if too many images are shown, loading data with query string ```?image=1234&image=5678....``` will exceed 4k length limit of gunicorn. Need to use different query or load data in batches or POST etc.