### PR TITLE
Plot clean up

### DIFF
--- a/omero_parade/static/omero_parade/css/parade.css
+++ b/omero_parade/static/omero_parade/css/parade.css
@@ -362,10 +362,10 @@ input[type=range].parade:focus::-ms-fill-upper {
 }
 
 .thumbnail_plot {
-  margin: 25px 50px;
+  margin: 25px 75px;
   margin-bottom: 0px;
   padding: 10px;
-  height: 352px;
+  height: 450px;
   box-sizing: border-box;
   border: solid black 1px;
   position: relative;

--- a/omero_parade/static/omero_parade/css/parade.css
+++ b/omero_parade/static/omero_parade/css/parade.css
@@ -362,8 +362,9 @@ input[type=range].parade:focus::-ms-fill-upper {
 }
 
 .thumbnail_plot {
-  margin: 50px 100px;
-  width: 502px;
+  margin: 25px 50px;
+  margin-bottom: 0px;
+  padding: 10px;
   height: 352px;
   box-sizing: border-box;
   border: solid black 1px;
@@ -371,9 +372,8 @@ input[type=range].parade:focus::-ms-fill-upper {
 }
 
 .thumbnail_plot_canvas {
-  margin: 10px;
-  width: 480px;
-  height: 330px;
+  width: 100%;
+  height: 100%;
   box-sizing: border-box;
   position: relative;
 }

--- a/omero_parade/static/omero_parade/css/parade.css
+++ b/omero_parade/static/omero_parade/css/parade.css
@@ -370,14 +370,15 @@ input[type=range].parade:focus::-ms-fill-upper {
   box-sizing: border-box;
   border: solid black 1px;
   position: relative;
+  min-width: 650px;
 }
 
 .thumbnail_plot_canvas {
   width: 100%;
-  min-width: 650px;
   height: 100%;
   box-sizing: border-box;
   position: relative;
+  z-index: 999;
 }
 
 .thumbnail_plot img {
@@ -396,18 +397,75 @@ input[type=range].parade:focus::-ms-fill-upper {
 }
 
 .parade_centrePanel .thumbnail_plot_canvas .data-point {
+  position: absolute;
   height: 10px;
   width: 10px;
   background-color: #1f4579;
-  border-radius: 50%
+  border-radius: 50%;
 }
 
 .parade_centrePanel .thumbnail_plot_canvas .ui-selected {
-  background-color: #33aba1
+  background-color: #33aba1;
 }
 
 .parade_centrePanel tr.ui-selected {
-  background-color: #33aba1
+  background-color: #33aba1;
+}
+
+.parade_centrePanel .plot-x-ticks {
+  z-index: -1;
+  height: 40px;
+  margin-left: 75px;
+  margin-right: 75px;
+  min-width: 650px;
+}
+
+.parade_centrePanel .plot-x-label {
+  min-width: 850px;
+  z-index: -1;
+  text-align: center;
+}
+
+.parade_centrePanel .plot-y-ticks {
+  z-index: -1;
+  margin-left: 75px;
+  margin-right: 75px;
+  transform: translateY(-509px);
+  min-width: 650px;
+}
+
+.parade_centrePanel .plot-y-label {
+  z-index: -1;
+  transform-origin: center;
+  transform: translate(-50%, 0) rotate(-90deg) translate(450px, 15px);
+  text-align: center;
+  width: 450px;
+}
+
+.parade_centrePanel line.plot-x-tick-lines {
+  stroke: black;
+  stroke-width: 1;
+  shape-rendering: crispedges;
+}
+
+.parade_centrePanel line.plot-x-grid-lines {
+  stroke: lightgray;
+  stroke-width: 1;
+  shape-rendering: crispedges;
+  stroke-dasharray: 5,5;
+}
+
+.parade_centrePanel line.plot-y-tick-lines {
+  stroke: black;
+  stroke-width: 1;
+  shape-rendering: crispedges;
+}
+
+.parade_centrePanel line.plot-y-grid-lines {
+  stroke: lightgray;
+  stroke-width: 1;
+  shape-rendering: crispedges;
+  stroke-dasharray: 5,5;
 }
 
 .plateGrid td.ui-selected img {

--- a/omero_parade/static/omero_parade/css/parade.css
+++ b/omero_parade/static/omero_parade/css/parade.css
@@ -353,6 +353,7 @@ input[type=range].parade:focus::-ms-fill-upper {
   text-align: center;
   font-size: 110%;
   padding: 3px;
+  vertical-align: middle;
 }
 
 .layoutHeader {
@@ -373,6 +374,7 @@ input[type=range].parade:focus::-ms-fill-upper {
 
 .thumbnail_plot_canvas {
   width: 100%;
+  min-width: 650px;
   height: 100%;
   box-sizing: border-box;
   position: relative;

--- a/omero_parade/static/omero_parade/css/parade.css
+++ b/omero_parade/static/omero_parade/css/parade.css
@@ -393,6 +393,21 @@ input[type=range].parade:focus::-ms-fill-upper {
   border: solid #87ABD2 3px;
 }
 
+.parade_centrePanel .thumbnail_plot_canvas .data-point {
+  height: 10px;
+  width: 10px;
+  background-color: #1f4579;
+  border-radius: 50%
+}
+
+.parade_centrePanel .thumbnail_plot_canvas .ui-selected {
+  background-color: #33aba1
+}
+
+.parade_centrePanel tr.ui-selected {
+  background-color: #33aba1
+}
+
 .plateGrid td.ui-selected img {
   border: solid transparent 3px;
 }

--- a/src/js/dataView/plot/DataPlot.js
+++ b/src/js/dataView/plot/DataPlot.js
@@ -58,12 +58,10 @@ class DataPlot extends React.Component {
             distance: 2,
             stop: () => {
                 // Make the same selection in the jstree etc
-                console.log("Selecting things");
                 let ids = [];
                 $(".thumbnail_plot_canvas .ui-selected").each(function(){
                     ids.push(parseInt($(this).attr(idAttr), 10));
                 });
-                console.log("Selected ids", dtype, ids);
                 this.props.setImagesWellsSelected(dtype, ids);
             },
         });

--- a/src/js/dataView/plot/DataPlot.js
+++ b/src/js/dataView/plot/DataPlot.js
@@ -22,15 +22,9 @@ import config from '../../config';
 
 const styles = {
     xAxisSelect: {
-        position: 'absolute',
-        right: '40%',
-        top: '100%',
     },
     yAxisSelect: {
-        position: 'absolute',
-        right: '100%',
-        top: '50%',
-        transform: 'rotate(-90deg)',
+
     },
 }
 class DataPlot extends React.Component {
@@ -83,8 +77,17 @@ class DataPlot extends React.Component {
             return 0;
         }
         let minMax = dataRanges[name];
-        let fraction = (value - minMax[0])/(minMax[1] - minMax[0]);
+        let fraction = (value - (minMax[0]))/((minMax[1]) - (minMax[0]));
         return fraction * 100;
+    }
+
+    getAxisTicks(dataRanges, name, numberOfTicks) {
+        let minMax = dataRanges[name];
+        let step = (minMax[1] - minMax[0]) / (numberOfTicks - 1);
+        let ticks = Array.from(
+            {length: numberOfTicks},
+            (x, i) => (minMax[0] + i * step).toFixed(2));
+        return ticks;
     }
 
     render() {
@@ -132,6 +135,10 @@ class DataPlot extends React.Component {
             }
             const x = tableData[xAxisName].data[image.id];
             const y = tableData[yAxisName].data[image.id];
+
+            let left_position = this.getAxisPercent(dataRanges, xAxisName, x);
+            let top_position = (100 - this.getAxisPercent(dataRanges, yAxisName, y));
+
             return (
                 <img alt="image"
                     key={image.id + (image.parent ? image.parent : "")}
@@ -142,26 +149,34 @@ class DataPlot extends React.Component {
                     title={image.name}
                     onClick={event => {handleImageWellClicked(image, event)}}
                     style={{
-                        left: this.getAxisPercent(dataRanges, xAxisName, x) + '%',
-                        top: (100 - this.getAxisPercent(dataRanges, yAxisName, y)) + '%'
+                        left: left_position + '%',
+                        top: top_position + '%'
                     }}
                 />
             )
         });
         return (
             <div className="parade_centrePanel">
-                <div className="thumbnail_plot">
-                    <select onChange={(event) => {this.setAxisName('y', event, xAxisName)}}
-                            value={yAxisName}
-                            style={styles.yAxisSelect}>
-                        {axisNames.map((n, i) => (<option key={i} value={n}> {n}</option>))}
-                    </select>
+                <div className="axis-x-label"  style={{transform: "translateY(435px)", textAlign: "center"}}>
                     <select onChange={(event) => {this.setAxisName('x', event, yAxisName)}}
                             value={xAxisName}
                             style={styles.xAxisSelect}>
                         {axisNames.map((n, i) => (<option key={i} value={n}> {n}</option>))}
                     </select>
-
+                </div>
+                <div className="axis y"
+                     style={{
+                        transformOrigin: "center",
+                        transform: "translate(-50%, 0) rotate(-90deg) translate(-210px,25px)",
+                        textAlign: "center"
+                    }}>
+                    <select onChange={(event) => {this.setAxisName('y', event, xAxisName)}}
+                            value={yAxisName}
+                            style={styles.yAxisSelect}>
+                        {axisNames.map((n, i) => (<option key={i} value={n}> {n}</option>))}
+                    </select>
+                </div>
+                <div className="thumbnail_plot">
                     <div className="thumbnail_plot_canvas" ref="thumb_plot_canvas">
                         {images}
                     </div>

--- a/src/js/dataView/plot/DataPlot.js
+++ b/src/js/dataView/plot/DataPlot.js
@@ -157,7 +157,7 @@ class DataPlot extends React.Component {
         });
         return (
             <div className="parade_centrePanel">
-                <div className="axis-x-label"  style={{transform: "translateY(435px)", textAlign: "center"}}>
+                <div className="axis-x-label"  style={{transform: "translateY(455px)", textAlign: "center"}}>
                     <select onChange={(event) => {this.setAxisName('x', event, yAxisName)}}
                             value={xAxisName}
                             style={styles.xAxisSelect}>
@@ -180,6 +180,30 @@ class DataPlot extends React.Component {
                     <div className="thumbnail_plot_canvas" ref="thumb_plot_canvas">
                         {images}
                     </div>
+                </div>
+                <div style={{marginLeft: '50px', marginRight: '50px'}}>
+                    <svg style={{width: "100%", resize: "both", fontSize: "10px", overflow: "inherit"}}>
+                        <g style={{width: "100%"}}>
+                            <line style={{stroke: "black", strokeWidth: 1, shapeRendering: "crispEdges", transform: "translateX(1px)"}} x1="0%" x2="0%" y2="10"></line>
+                            <text x="0%" y="25" style={{transform: "translateX(-10px)"}}> 0%</text>
+                        </g>
+                        <g>
+                            <line style={{stroke: "black", strokeWidth: 1, shapeRendering: "crispEdges"}} x1="25%" x2="25%" y2="10"></line>
+                            <text y="25" x="25%" style={{transform: "translateX(-10px)"}}>25%</text>
+                        </g>
+                        <g>
+                                <line style={{stroke: "black", strokeWidth: 1, shapeRendering: "crispEdges"}} x1="50%" x2="50%" y2="10"></line>
+                            <text x="50%" y="25" style={{transform: "translateX(-10px)"}}>50%</text>
+                        </g>
+                        <g>
+                            <line style={{stroke: "black", strokeWidth: 1, shapeRendering: "crispEdges"}} x1="75%" x2="75%" y2="10"></line>
+                            <text x="75%" y="25" style={{transform: "translateX(-10px)"}}>75%</text>
+                        </g>
+                        <g>
+                            <line style={{stroke: "black", strokeWidth: 1, shapeRendering: "crispEdges"}} x1="100%" x2="100%" y2="10"></line>
+                            <text x="100%" y="25" style={{transform: "translateX(-10px)"}}>100%</text>
+                        </g>
+                    </svg>
                 </div>
             </div>
         );

--- a/src/js/dataView/plot/DataPlot.js
+++ b/src/js/dataView/plot/DataPlot.js
@@ -142,6 +142,7 @@ class DataPlot extends React.Component {
             const x = tableData[xAxisName].data[image.id];
             const y = tableData[yAxisName].data[image.id];
 
+            {/* Tooltip info */}
             let properties = "";
             for (let key in tableData) {
                 if (key != xAxisName && key != yAxisName) {
@@ -155,7 +156,6 @@ class DataPlot extends React.Component {
             return (
                 <div
                     style={{
-                        position: "absolute",
                         left: left_position + '%',
                         top: top_position + '%'}}
                     key={image.id + (image.parent ? image.parent : "")}
@@ -169,35 +169,6 @@ class DataPlot extends React.Component {
                         properties}
                     onClick={event => {handleImageWellClicked(image, event)}}
                 ></div>
-                /*
-                <circle
-                    cx={left_position + '%'}
-                    cy={top_position + '%'}
-                    r="5"
-                    stroke="#33aba1"
-                    strokeWidth="1"
-                    fill="#1f4579"
-                    key={image.id + (image.parent ? image.parent : "")}
-                    className={classNames.join(" ")}
-                    data-id={image.id}
-                    data-wellid={image.wellId}
-                    title={image.name}
-                    onClick={event => {handleImageWellClicked(image, event)}}
-                />
-                */
-                /*<img alt="image"
-                    key={image.id + (image.parent ? image.parent : "")}
-                    className={classNames.join(" ")}
-                    data-id={image.id}
-                    data-wellid={image.wellId}
-                    src={src}
-                    title={image.name}
-                    onClick={event => {handleImageWellClicked(image, event)}}
-                    style={{
-                        left: left_position + '%',
-                        top: top_position + '%'
-                    }}
-                />*/
             )
         });
         const lineStyle = {
@@ -209,24 +180,28 @@ class DataPlot extends React.Component {
         const xAxisLabelValues = this.getAxisTicks(
             dataRanges, xAxisName, xAxisLabelScale);
         const xAxisTicks = xAxisLabelScale.map( (label, index) => {
-            let transform = ""
+            const xPos = label + "%";
             if (label == 0) {
-                transform = "translateX(1px)";
-            } else {
-                transform = "translateX(0px)";
-            }
-            if (label == 0 || label == 100) {
                 return (
                     <g>
-                        <line style={{
-                                stroke: "black", strokeWidth: 1,
-                                shapeRendering: "crispEdges",
-                                transform: transform}}
-                              x1={label + "%"}
-                              x2={label + "%"}
-                              y2="10">
+                        <line className="plot-x-tick-lines"
+                              x1={xPos} x2={xPos} y2="10"
+                              style={{transform: "translateX(1px)"}}>
                         </line>
-                        <text x={label + "%"} y="25" style={{transform: "translateX(-10px)"}}>
+                        <text x={xPos} y="25"
+                              style={{transform: "translateX(-10px)"}}>
+                            {xAxisLabelValues[index]}
+                        </text>
+                    </g>
+                )
+            } else if (label == 100) {
+                return (
+                    <g>
+                        <line className="plot-x-tick-lines"
+                              x1={xPos} x2={xPos} y2="10">
+                        </line>
+                        <text x={xPos} y="25"
+                              style={{transform: "translateX(-10px)"}}>
                             {xAxisLabelValues[index]}
                         </text>
                     </g>
@@ -234,20 +209,14 @@ class DataPlot extends React.Component {
             } else {
                 return (
                     <g>
-                        <line style={{
-                                stroke: "black", strokeWidth: 1,
-                                shapeRendering: "crispEdges",
-                                transform: transform}}
-                              x1={label + "%"}
-                              x2={label + "%"}
-                              y2="10">
-                            </line>
-                        <line style={{
-                                stroke: "gray", strokeWidth: 1,
-                                strokeDasharray: "5,5", shapeRendering: "crispEdges",
-                                transform: transform}}
-                              x1={label + "%"} x2={label + "%"} y2={-plotHeight}></line>
-                        <text x={label + "%"} y="25" style={{transform: "translateX(-10px)"}}>
+                        <line className="plot-x-tick-lines"
+                              x1={xPos} x2={xPos} y2="10">
+                        </line>
+                        <line className="plot-x-grid-lines"
+                              x1={xPos} x2={xPos} y2={-plotHeight}>
+                        </line>
+                        <text x={xPos} y="25"
+                              style={{transform: "translateX(-10px)"}}>
                             {xAxisLabelValues[index]}
                         </text>
                     </g>
@@ -257,19 +226,27 @@ class DataPlot extends React.Component {
         const yAxisLabelScale = [0, 33, 66, 100];
         const yAxisLabelValues = this.getAxisTicks(
             dataRanges, yAxisName, yAxisLabelScale);
-        {/* taken from css */}
         const yAxisTicks = yAxisLabelScale.map( (label, index) => {
-            if (label == 0 || label == 100) {
+            const yPos = (100 - label) * plotHeight / 100;
+            if (label == 0) {
                 return (
                     <g>
-                        <line style={{
-                                stroke: "black", strokeWidth: 1,
-                                shapeRendering: "crispEdges"}}
-                              y1={(100 - label) * plotHeight / 100}
-                              y2={(100 - label) * plotHeight / 100}
-                              x2="-10">
+                        <line className="plot-y-tick-lines"
+                              y1={yPos} y2={yPos} x2="-10">
                         </line>
-                        <text y={((100 - label) * plotHeight / 100) - 5} x="-45">
+                        <text x="-45" y={yPos - 5}>
+                            {yAxisLabelValues[index]}
+                        </text>
+                    </g>
+                )
+            } else if (label == 100) {
+                return (
+                    <g>
+                        <line className="plot-y-tick-lines"
+                              y1={yPos} y2={yPos} x2="-10"
+                              style={{transform: "translateY(1px)"}}>
+                        </line>
+                        <text x="-45" y={yPos - 5}>
                             {yAxisLabelValues[index]}
                         </text>
                     </g>
@@ -277,21 +254,13 @@ class DataPlot extends React.Component {
             } else {
                 return (
                     <g>
-                        <line style={{
-                                stroke: "black", strokeWidth: 1,
-                                shapeRendering: "crispEdges"}}
-                              y1={(100 - label) * plotHeight / 100}
-                              y2={(100 - label) * plotHeight / 100}
-                              x2="-10">
+                        <line className="plot-y-tick-lines"
+                              y1={yPos} y2={yPos} x2="-10">
                         </line>
-                        <line style={{
-                                stroke: "gray", strokeWidth: 1,
-                                strokeDasharray: "5,5", shapeRendering: "crispEdges"}}
-                              y1={(100 - label) * plotHeight / 100}
-                              y2={(100 - label) * plotHeight / 100}
-                              x2="100%">
+                        <line className="plot-y-grid-lines"
+                              y1={yPos} y2={yPos} x2="100%">
                         </line>
-                        <text y={((100 - label) * plotHeight / 100) - 5} x="-45">
+                        <text x="-45" y={yPos - 5}>
                             {yAxisLabelValues[index]}
                         </text>
                     </g>
@@ -301,28 +270,19 @@ class DataPlot extends React.Component {
         return (
             <div className="parade_centrePanel">
                 {/* The Plot */}
-                {/*}
-                <div className="thumbnail_plot">
-                    <div className="thumbnail_plot_canvas1" ref="thumb_plot_canvas1">
-                        <svg className="thumbnail_plot_canvas" ref="thumb_plot_canvas" style={{width: "100%", height: plotHeight - 20 + "px", overflow: "inherit"}}>
-                            {images}
-                        </svg>
-                    </div>
-                </div>
-                */}
                 <div className="thumbnail_plot">
                     <div className="thumbnail_plot_canvas" ref="thumb_plot_canvas" style={{zIndex: 1000}}>
                         {images}
                     </div>
                 </div>
                 {/* X Axis Ticks */}
-                <div className="xTicks" style={{zindex: -1, height: "40px", marginLeft: '75px', marginRight: '75px'}}>
+                <div className="plot-x-ticks">
                     <svg style={{width: "100%", resize: "both", fontSize: "10px", overflow: "inherit"}}>
                         {xAxisTicks}
                     </svg>
                 </div>
                 {/* X Axis Label */}
-                <div className="axis-x-label"  style={{zIndex: -1, textAlign: "center"}}>
+                <div className="plot-x-label">
                     <select onChange={(event) => {this.setAxisName('x', event, yAxisName)}}
                             value={xAxisName}
                             style={styles.xAxisSelect}>
@@ -330,19 +290,13 @@ class DataPlot extends React.Component {
                     </select>
                 </div>
                 {/* Y AXis Ticks */}
-                <div className="yTicks" style={{zIndex: -1, marginLeft: '75px', marginRight: '75px', transform: "translateY(-509px)"}}>
+                <div className="plot-y-ticks">
                     <svg style={{width: "100%", resize: "both", fontSize: "10px", overflow: "inherit"}}>
                         {yAxisTicks}
                     </svg>
                 </div>
                 {/* Y Axis Label */}
-                <div className="axis y"
-                     style={{
-                        zIndex: -1,
-                        transformOrigin: "center",
-                        transform: "translate(-50%, 0) rotate(-90deg) translate(450px, 15px)",
-                        textAlign: "center"
-                    }}>
+                <div className="plot-y-label">
                     <select onChange={(event) => {this.setAxisName('y', event, xAxisName)}}
                             value={yAxisName}
                             style={styles.yAxisSelect}>

--- a/src/js/dataView/plot/DataPlot.js
+++ b/src/js/dataView/plot/DataPlot.js
@@ -81,8 +81,12 @@ class DataPlot extends React.Component {
         return fraction * 100;
     }
 
-    getAxisTicks(dataRanges, name, numberOfTicks) {
+    getAxisTicks(dataRanges, name, axisScales) {
         let minMax = dataRanges[name];
+        let tickValues = axisScales.map( (scale, index) => {
+            return (minMax[0] + ((minMax[1] - minMax[0]) * scale / 100.0)).toFixed(2);
+        });
+        return tickValues;
         let step = (minMax[1] - minMax[0]) / (numberOfTicks - 1);
         let ticks = Array.from(
             {length: numberOfTicks},
@@ -155,19 +159,137 @@ class DataPlot extends React.Component {
                 />
             )
         });
+        const lineStyle = {
+            stroke: 'black',
+            strokeWidth: 1
+        }
+        const plotHeight = 450;
+        const xAxisLabelScale = [0, 25, 50, 75, 100];
+        const xAxisLabelValues = this.getAxisTicks(
+            dataRanges, xAxisName, xAxisLabelScale);
+        const xAxisTicks = xAxisLabelScale.map( (label, index) => {
+            let transform = ""
+            if (label == 0) {
+                transform = "translateX(1px)";
+            } else {
+                transform = "translateX(0px)";
+            }
+            if (label == 0 || label == 100) {
+                return (
+                    <g>
+                        <line style={{
+                                stroke: "black", strokeWidth: 1,
+                                shapeRendering: "crispEdges",
+                                transform: transform}}
+                              x1={label + "%"}
+                              x2={label + "%"}
+                              y2="10">
+                        </line>
+                        <text x={label + "%"} y="25" style={{transform: "translateX(-10px)"}}>
+                            {xAxisLabelValues[index]}
+                        </text>
+                    </g>
+                )
+            } else {
+                return (
+                    <g>
+                        <line style={{
+                                stroke: "black", strokeWidth: 1,
+                                shapeRendering: "crispEdges",
+                                transform: transform}}
+                              x1={label + "%"}
+                              x2={label + "%"}
+                              y2="10">
+                            </line>
+                        <line style={{
+                                stroke: "gray", strokeWidth: 1,
+                                strokeDasharray: "5,5", shapeRendering: "crispEdges",
+                                transform: transform}}
+                              x1={label + "%"} x2={label + "%"} y2={-plotHeight}></line>
+                        <text x={label + "%"} y="25" style={{transform: "translateX(-10px)"}}>
+                            {xAxisLabelValues[index]}
+                        </text>
+                    </g>
+                )
+            }
+        });
+        const yAxisLabelScale = [0, 33, 66, 100];
+        const yAxisLabelValues = this.getAxisTicks(
+            dataRanges, yAxisName, yAxisLabelScale);
+        {/* taken from css */}
+        const yAxisTicks = yAxisLabelScale.map( (label, index) => {
+            if (label == 0 || label == 100) {
+                return (
+                    <g>
+                        <line style={{
+                                stroke: "black", strokeWidth: 1,
+                                shapeRendering: "crispEdges"}}
+                              y1={(100 - label) * plotHeight / 100}
+                              y2={(100 - label) * plotHeight / 100}
+                              x2="-10">
+                        </line>
+                        <text y={((100 - label) * plotHeight / 100) - 5} x="-45">
+                            {yAxisLabelValues[index]}
+                        </text>
+                    </g>
+                )
+            } else {
+                return (
+                    <g>
+                        <line style={{
+                                stroke: "black", strokeWidth: 1,
+                                shapeRendering: "crispEdges"}}
+                              y1={(100 - label) * plotHeight / 100}
+                              y2={(100 - label) * plotHeight / 100}
+                              x2="-10">
+                        </line>
+                        <line style={{
+                                stroke: "gray", strokeWidth: 1,
+                                strokeDasharray: "5,5", shapeRendering: "crispEdges"}}
+                              y1={(100 - label) * plotHeight / 100}
+                              y2={(100 - label) * plotHeight / 100}
+                              x2="100%">
+                        </line>
+                        <text y={((100 - label) * plotHeight / 100) - 5} x="-45">
+                            {yAxisLabelValues[index]}
+                        </text>
+                    </g>
+                )
+            }
+        });
         return (
             <div className="parade_centrePanel">
-                <div className="axis-x-label"  style={{transform: "translateY(455px)", textAlign: "center"}}>
+                {/* The Plot */}
+                <div className="thumbnail_plot">
+                    <div className="thumbnail_plot_canvas" ref="thumb_plot_canvas">
+                        {images}
+                    </div>
+                </div>
+                {/* X Axis Ticks */}
+                <div className="xTicks" style={{height: "40px", marginLeft: '75px', marginRight: '75px'}}>
+                    <svg style={{width: "100%", resize: "both", fontSize: "10px", overflow: "inherit"}}>
+                        {xAxisTicks}
+                    </svg>
+                </div>
+                {/* X Axis Label */}
+                <div className="axis-x-label"  style={{textAlign: "center"}}>
                     <select onChange={(event) => {this.setAxisName('x', event, yAxisName)}}
                             value={xAxisName}
                             style={styles.xAxisSelect}>
                         {axisNames.map((n, i) => (<option key={i} value={n}> {n}</option>))}
                     </select>
                 </div>
+                {/* Y AXis Ticks */}
+                <div className="yTicks" style={{marginLeft: '75px', marginRight: '75px', transform: "translateY(-509px)"}}>
+                    <svg style={{width: "100%", resize: "both", fontSize: "10px", overflow: "inherit"}}>
+                        {yAxisTicks}
+                    </svg>
+                </div>
+                {/* Y Axis Label */}
                 <div className="axis y"
                      style={{
                         transformOrigin: "center",
-                        transform: "translate(-50%, 0) rotate(-90deg) translate(-210px,25px)",
+                        transform: "translate(-50%, 0) rotate(-90deg) translate(450px, 15px)",
                         textAlign: "center"
                     }}>
                     <select onChange={(event) => {this.setAxisName('y', event, xAxisName)}}
@@ -175,35 +297,6 @@ class DataPlot extends React.Component {
                             style={styles.yAxisSelect}>
                         {axisNames.map((n, i) => (<option key={i} value={n}> {n}</option>))}
                     </select>
-                </div>
-                <div className="thumbnail_plot">
-                    <div className="thumbnail_plot_canvas" ref="thumb_plot_canvas">
-                        {images}
-                    </div>
-                </div>
-                <div style={{marginLeft: '50px', marginRight: '50px'}}>
-                    <svg style={{width: "100%", resize: "both", fontSize: "10px", overflow: "inherit"}}>
-                        <g style={{width: "100%"}}>
-                            <line style={{stroke: "black", strokeWidth: 1, shapeRendering: "crispEdges", transform: "translateX(1px)"}} x1="0%" x2="0%" y2="10"></line>
-                            <text x="0%" y="25" style={{transform: "translateX(-10px)"}}> 0%</text>
-                        </g>
-                        <g>
-                            <line style={{stroke: "black", strokeWidth: 1, shapeRendering: "crispEdges"}} x1="25%" x2="25%" y2="10"></line>
-                            <text y="25" x="25%" style={{transform: "translateX(-10px)"}}>25%</text>
-                        </g>
-                        <g>
-                                <line style={{stroke: "black", strokeWidth: 1, shapeRendering: "crispEdges"}} x1="50%" x2="50%" y2="10"></line>
-                            <text x="50%" y="25" style={{transform: "translateX(-10px)"}}>50%</text>
-                        </g>
-                        <g>
-                            <line style={{stroke: "black", strokeWidth: 1, shapeRendering: "crispEdges"}} x1="75%" x2="75%" y2="10"></line>
-                            <text x="75%" y="25" style={{transform: "translateX(-10px)"}}>75%</text>
-                        </g>
-                        <g>
-                            <line style={{stroke: "black", strokeWidth: 1, shapeRendering: "crispEdges"}} x1="100%" x2="100%" y2="10"></line>
-                            <text x="100%" y="25" style={{transform: "translateX(-10px)"}}>100%</text>
-                        </g>
-                    </svg>
                 </div>
             </div>
         );

--- a/src/js/dataView/plot/DataPlot.js
+++ b/src/js/dataView/plot/DataPlot.js
@@ -54,14 +54,16 @@ class DataPlot extends React.Component {
         let dtype = this.props.imgJson[0].wellId ? 'well' : 'image';
         let idAttr = (dtype === 'well' ? 'data-wellid': 'data-id')
         $(this.refs.thumb_plot_canvas).selectable({
-            filter: 'img',
+            filter: 'div',
             distance: 2,
             stop: () => {
                 // Make the same selection in the jstree etc
+                console.log("Selecting things");
                 let ids = [];
                 $(".thumbnail_plot_canvas .ui-selected").each(function(){
                     ids.push(parseInt($(this).attr(idAttr), 10));
                 });
+                console.log("Selected ids", dtype, ids);
                 this.props.setImagesWellsSelected(dtype, ids);
             },
         });
@@ -140,11 +142,50 @@ class DataPlot extends React.Component {
             const x = tableData[xAxisName].data[image.id];
             const y = tableData[yAxisName].data[image.id];
 
+            let properties = "";
+            for (let key in tableData) {
+                if (key != xAxisName && key != yAxisName) {
+                    properties += "\n" + key + ": " + tableData[key].data[image.id];
+                }
+            }
+
             let left_position = this.getAxisPercent(dataRanges, xAxisName, x);
             let top_position = (100 - this.getAxisPercent(dataRanges, yAxisName, y));
-
+            classNames.push("data-point");
             return (
-                <img alt="image"
+                <div
+                    style={{
+                        position: "absolute",
+                        left: left_position + '%',
+                        top: top_position + '%'}}
+                    key={image.id + (image.parent ? image.parent : "")}
+                    className={classNames.join(" ")}
+                    data-id={image.id}
+                    data-wellid={image.wellId}
+                    title={
+                        "Image Name: " + image.name +
+                        "\n" + xAxisName + ": " + x +
+                        "\n" + yAxisName + ": " + y +
+                        properties}
+                    onClick={event => {handleImageWellClicked(image, event)}}
+                ></div>
+                /*
+                <circle
+                    cx={left_position + '%'}
+                    cy={top_position + '%'}
+                    r="5"
+                    stroke="#33aba1"
+                    strokeWidth="1"
+                    fill="#1f4579"
+                    key={image.id + (image.parent ? image.parent : "")}
+                    className={classNames.join(" ")}
+                    data-id={image.id}
+                    data-wellid={image.wellId}
+                    title={image.name}
+                    onClick={event => {handleImageWellClicked(image, event)}}
+                />
+                */
+                /*<img alt="image"
                     key={image.id + (image.parent ? image.parent : "")}
                     className={classNames.join(" ")}
                     data-id={image.id}
@@ -156,7 +197,7 @@ class DataPlot extends React.Component {
                         left: left_position + '%',
                         top: top_position + '%'
                     }}
-                />
+                />*/
             )
         });
         const lineStyle = {
@@ -260,19 +301,28 @@ class DataPlot extends React.Component {
         return (
             <div className="parade_centrePanel">
                 {/* The Plot */}
+                {/*}
                 <div className="thumbnail_plot">
-                    <div className="thumbnail_plot_canvas" ref="thumb_plot_canvas">
+                    <div className="thumbnail_plot_canvas1" ref="thumb_plot_canvas1">
+                        <svg className="thumbnail_plot_canvas" ref="thumb_plot_canvas" style={{width: "100%", height: plotHeight - 20 + "px", overflow: "inherit"}}>
+                            {images}
+                        </svg>
+                    </div>
+                </div>
+                */}
+                <div className="thumbnail_plot">
+                    <div className="thumbnail_plot_canvas" ref="thumb_plot_canvas" style={{zIndex: 1000}}>
                         {images}
                     </div>
                 </div>
                 {/* X Axis Ticks */}
-                <div className="xTicks" style={{height: "40px", marginLeft: '75px', marginRight: '75px'}}>
+                <div className="xTicks" style={{zindex: -1, height: "40px", marginLeft: '75px', marginRight: '75px'}}>
                     <svg style={{width: "100%", resize: "both", fontSize: "10px", overflow: "inherit"}}>
                         {xAxisTicks}
                     </svg>
                 </div>
                 {/* X Axis Label */}
-                <div className="axis-x-label"  style={{textAlign: "center"}}>
+                <div className="axis-x-label"  style={{zIndex: -1, textAlign: "center"}}>
                     <select onChange={(event) => {this.setAxisName('x', event, yAxisName)}}
                             value={xAxisName}
                             style={styles.xAxisSelect}>
@@ -280,7 +330,7 @@ class DataPlot extends React.Component {
                     </select>
                 </div>
                 {/* Y AXis Ticks */}
-                <div className="yTicks" style={{marginLeft: '75px', marginRight: '75px', transform: "translateY(-509px)"}}>
+                <div className="yTicks" style={{zIndex: -1, marginLeft: '75px', marginRight: '75px', transform: "translateY(-509px)"}}>
                     <svg style={{width: "100%", resize: "both", fontSize: "10px", overflow: "inherit"}}>
                         {yAxisTicks}
                     </svg>
@@ -288,6 +338,7 @@ class DataPlot extends React.Component {
                 {/* Y Axis Label */}
                 <div className="axis y"
                      style={{
+                        zIndex: -1,
                         transformOrigin: "center",
                         transform: "translate(-50%, 0) rotate(-90deg) translate(450px, 15px)",
                         textAlign: "center"

--- a/src/js/dataView/table/DatasetTable.js
+++ b/src/js/dataView/table/DatasetTable.js
@@ -65,7 +65,7 @@ class DatasetTable extends React.Component {
                 )
             });
             return (
-                <tr key={image.id + (image.parent ? image.parent : "")}>
+                <tr className={classNames.join(" ")} key={image.id + (image.parent ? image.parent : "")}>
                     <td><img alt="image"
                             className={classNames.join(" ")}
                             width={iconSize + "px"}


### PR DESCRIPTION
List of changes:

* plot is now re-sizable in width with the min-width set to 650px
* scales, ticks, and grid lines are added; grid lines are fixed for now to 2 along Y and 3 along X
* img -> point:
![picture2](https://user-images.githubusercontent.com/2600663/40173859-80d4da0e-59d3-11e8-87af-d5960da9e366.PNG)

* tooltip with table values:
![picture1](https://user-images.githubusercontent.com/2600663/40173871-8cd0b0da-59d3-11e8-8578-7ad793f36089.png)

* multiselection with points:
![picture3](https://user-images.githubusercontent.com/2600663/40173892-9be3f4b0-59d3-11e8-997a-f75ac090f8b1.PNG)

* table row highlighting
![picture4](https://user-images.githubusercontent.com/2600663/40173911-a8a9af00-59d3-11e8-88d6-3d456640ae11.PNG)
 
