### PR TITLE
firefox_axis_select

### DIFF
--- a/omero_parade/static/omero_parade/css/parade.css
+++ b/omero_parade/static/omero_parade/css/parade.css
@@ -435,7 +435,6 @@ input[type=range].parade:focus::-ms-fill-upper {
 }
 
 .parade_centrePanel .plot-y-label {
-  z-index: -1;
   transform-origin: center;
   transform: translate(-50%, 0) rotate(-90deg) translate(450px, 15px);
   text-align: center;


### PR DESCRIPTION
This fixes the visibility of the plot Y-axis select widget on Firefox.

cc @pwalczysko @jburel 

To test: Y-axis select element should be visible on Firefox (and still working OK on chrome)

<img width="548" alt="screen shot 2018-09-05 at 23 30 18" src="https://user-images.githubusercontent.com/900055/45124852-d3514f00-b163-11e8-9f27-8dfb7e04e304.png">
