### PR TITLE
table filter reset

### DIFF
--- a/src/js/filter/FilterHub.js
+++ b/src/js/filter/FilterHub.js
@@ -103,13 +103,13 @@ class FilterHub extends React.Component {
         });
     }
 
-    handleFilterChange(filterIndex, paramName, paramValue) {
+    handleFilterChange(filterIndex, paramState) {
         // A parameter has changed in one of the list of filters...
         this.setState(prevState => {
-            // Copy the previous set of values for the filter at this index...
-            let newValues = Object.assign({}, prevState.filterValues[filterIndex]);
-            // Assign the new value...
-            newValues[paramName] = paramValue;
+            // Copy the previous set of values for the filter at this index,
+            // and apply the new paramState
+            let newValues = Object.assign({}, prevState.filterValues[filterIndex],
+                                              paramState);
             // Make a copy of the previous list of parameter values
             let filterValues = [...prevState.filterValues];
             // And add back the new object to the correct index

--- a/src/js/filter/FilterInput.js
+++ b/src/js/filter/FilterInput.js
@@ -37,7 +37,13 @@ class FilterInput extends React.Component {
         if (max == undefined) {
             return value;
         }
+        if (value == undefined) {
+            value = "";
+        }
         let padding = max.toString().length - value.toString().length;
+        if (isNaN(padding) || padding < 0) {
+            padding = 0;
+        }
         return "\u2007".repeat(padding) + value;
     }
 

--- a/src/js/filter/ParadeFilter.js
+++ b/src/js/filter/ParadeFilter.js
@@ -71,7 +71,6 @@ class ParadeFilter extends React.Component {
     }
     
     handleFilterInput(paramName, value) {
-        this.props.handleFilterChange(this.props.filterIndex, paramName, value);
         // Depending on how many filter parameters we have, their type, and
         // the availability of additional metadata this method may be invoked
         // by several other event handlers.  The defining characteristic that
@@ -81,6 +80,11 @@ class ParadeFilter extends React.Component {
         let filterParam = this.state.filterParams.filter(v => {
             return v.name === paramName;
         })[0];
+
+        // If this filterParam object has extra data (histogram, min, max)
+        // Then we assume it is the first param of a Table filter
+        // and we are switching to a different column (named 'value')
+        // We try to update the histogram, min & max values for this column
         if (filterParam.histograms) {
             this.setState({
                 histogram: filterParam.histograms[value]
@@ -96,6 +100,16 @@ class ParadeFilter extends React.Component {
                 maximum: filterParam.maxima[value]
             });
         }
+
+        let paramState = {};
+        paramState[paramName] = value;
+
+        // Also for Table filter, if switching column we want to reset the
+        // 'count' we are filtering by.
+        if (filterParam.maxima && filterParam.minima !== undefined) {
+            paramState.count = undefined;
+        }
+        this.props.handleFilterChange(this.props.filterIndex, paramState);
     }
 
     render() {


### PR DESCRIPTION
This fixes some issues seen when switching the Table Filter between different columns, when column values are quite different from one another. Previously, the filter-value was not updated so we initially filter the values of one column using the old filter-value from the previous column, which often results in ALL images being filtered (can result in Parade being entirely reset).

Now, we reset the filter value to ```undefined``` when switching column, so that no images are filtered out until you start to drag the slider again.

To test:
 - switch between a bunch of columns of the Table filter, e.g. for idr0021 data, setting various filter values for each.
 - Each time you switch filter, all the images should be shown (none filtered) until you set a new value for that column.

cc @pwalczysko @jburel @chris-allan 