### PR TITLE
support string columns table data

### DIFF
--- a/omero_parade/views.py
+++ b/omero_parade/views.py
@@ -184,7 +184,7 @@ def get_data(request, data_name, conn=None, **kwargs):
                         rv['histogram'] = histogram.tolist()
                     except TypeError:
                         pass
-                    return JsonResponse(rv);
+                    return JsonResponse(rv)
         except ImportError:
             pass
 

--- a/omero_parade/views.py
+++ b/omero_parade/views.py
@@ -169,18 +169,22 @@ def get_data(request, data_name, conn=None, **kwargs):
                 if data_name in dp:
                     data = module.get_data(request, data_name, conn)
                     values = numpy.array(data.values())
-                    bins = 10
-                    if NUMPY_GT_1_11_0:
-                        # numpy.histogram() only supports bin calculation
-                        # from 1.11.0 onwards
-                        bins = 'auto'
-                    histogram, bin_edges = numpy.histogram(values, bins=bins)
-                    return JsonResponse({
-                        'data': data,
-                        'min': numpy.amin(values).item(),
-                        'max': numpy.amax(values).item(),
-                        'histogram': histogram.tolist()
-                    })
+                    rv = {'data': data}
+                    # Adding histogram etc will fail if data is not numerical
+                    try:
+                        rv['min'] = numpy.amin(values).item()
+                        rv['max'] = numpy.amax(values).item()
+                        bins = 10
+                        if NUMPY_GT_1_11_0:
+                            # numpy.histogram() only supports bin calculation
+                            # from 1.11.0 onwards
+                            bins = 'auto'
+                        histogram, bin_edges = numpy.histogram(values,
+                                                               bins=bins)
+                        rv['histogram'] = histogram.tolist()
+                    except TypeError:
+                        pass
+                    return JsonResponse(rv);
         except ImportError:
             pass
 


### PR DESCRIPTION
See https://github.com/ome/omero-parade/issues/47

This allows table data in String columns to be loaded.
To test:
 - Create table with string columns, e.g as described at https://github.com/ome/omero-parade/issues/47#issuecomment-414998542
 - In OMERO.parade, click ```Add table data...``` and choose a String column
 - Data should be loaded, displayed and is sortable etc

<img width="562" alt="Screen Shot 2019-03-11 at 03 42 31" src="https://user-images.githubusercontent.com/900055/54099208-f75e4900-43af-11e9-817b-ae4a26e99c0c.png">

This simply ignores any ```TypeError``` when generating histogram or min/max values for data.
At this point we don't know the column type, so we can't test for numerical columns (as we do for filtering at https://github.com/ome/omero-parade/blob/master/omero_parade/table_filters/omero_filters.py#L74)
I don't know what the intended usage of the ```min, max, and histogram``` JSON data was in the UI. It doesn't seem to be used currently, but there may be plans to use it?
cc @chris-allan @emilroz 