### PR TITLE
Fix loading of Key-Value pairs

### DIFF
--- a/omero_parade/annotation_filters/omero_filters.py
+++ b/omero_parade/annotation_filters/omero_filters.py
@@ -194,7 +194,7 @@ def get_script(request, script_name, conn):
         """ % (json.dumps(map_values), key_placeholder, js_object_attr,
                js_object_attr)
 
-        keys = map_values.keys()
+        keys = list(map_values.keys())
         keys.sort(key=lambda x: x.lower())
 
         filter_params = [{'name': 'key',


### PR DESCRIPTION
Fixes loading of Key-Value pairs on Python3. Error was 
```
AttributeError: 'dict_keys' object has no attribute 'sort'
```

To test just this fix on py3-ci, you can go to 
https://py3-ci.openmicroscopy.org/web/parade/filters/script/Key_Value/?project=2357 (user-3).
which is currently failing.

To test the full app locally, you need to install merged branch from snoopy (py3-ci not building JavaScript).
