### PR TITLE
heatmap fix py3

### DIFF
--- a/omero_parade/views.py
+++ b/omero_parade/views.py
@@ -149,12 +149,14 @@ def dataprovider_list(request, conn=None, **kwargs):
 
     return JsonResponse({'data': dps})
 
+
 def numpy_to_json(value):
     if isinstance(value, numpy.integer):
         return int(value)
     elif isinstance(value, numpy.floating):
         return float(value)
     return value
+
 
 @login_required()
 def get_data(request, data_name, conn=None, **kwargs):


### PR DESCRIPTION
This will fix heatmap (in table) and the scatter plot.
Currently https://py3-ci.openmicroscopy.org/web/parade/data/Uk9JX2NvdW50/?project=2357 does not contain valid min, max values.
To test: when this PR is deployed, that URL will contain valid min & max values (and histogram).

NB: I will configure the OMERO.web py3 ci job to deploy the merged build, but that will break the JavaScript. Which is why the testing will involve the URL only (not the UI).