### PR TITLE
z-index tag dialog fix

### DIFF
--- a/omero_parade/static/omero_parade/css/parade.css
+++ b/omero_parade/static/omero_parade/css/parade.css
@@ -378,7 +378,6 @@ input[type=range].parade:focus::-ms-fill-upper {
   height: 100%;
   box-sizing: border-box;
   position: relative;
-  z-index: 999;
 }
 
 .thumbnail_plot img {

--- a/omero_parade/static/omero_parade/css/parade.css
+++ b/omero_parade/static/omero_parade/css/parade.css
@@ -378,6 +378,7 @@ input[type=range].parade:focus::-ms-fill-upper {
   height: 100%;
   box-sizing: border-box;
   position: relative;
+  z-index: 1;
 }
 
 .thumbnail_plot img {

--- a/src/js/dataView/plot/DataPlot.js
+++ b/src/js/dataView/plot/DataPlot.js
@@ -269,7 +269,7 @@ class DataPlot extends React.Component {
             <div className="parade_centrePanel">
                 {/* The Plot */}
                 <div className="thumbnail_plot">
-                    <div className="thumbnail_plot_canvas" ref="thumb_plot_canvas" style={{zIndex: 1000}}>
+                    <div className="thumbnail_plot_canvas" ref="thumb_plot_canvas">
                         {images}
                     </div>
                 </div>


### PR DESCRIPTION
This fixes the bug where the Tag dialog appears behind the parade scatter plot.

To test:
 - View scatter plot in parade
 - Select Image(s) and open Tag dialog - should work normally.
 - Check for other css issues?

I don't know what issue the z-index css was trying to fix, or if it's still needed at-all? Any ideas @emilroz ? 