### PR TITLE
csv support

### DIFF
--- a/omero_parade/csv_filters/data_providers.py
+++ b/omero_parade/csv_filters/data_providers.py
@@ -100,13 +100,15 @@ def get_data(request, data_name, conn):
 
     data_col_idx = first_row.index(col_name)
     # TODO handle SPW, Well
-    # handle csv from Batch_ROI_Export.py which uses 'image_id'
-    if 'Image' not in first_row and 'image_id' in first_row:
-        first_row[first_row.index('image_id')] = 'Image'
+    # handle 'Image' column named 'image' or 'image_id'
+    img_names = ['Image', 'image', 'image_id']
+    img_col_idx = -1
+    for name in img_names:
+        if name in first_row:
+            img_col_idx = first_row.index(name)
+            break
 
-    img_col_idx = first_row.index('Image')
     table_data = {}
-
     for row in csv_reader:
         img_id = row[img_col_idx].strip()
         value = row[data_col_idx].strip()

--- a/omero_parade/csv_filters/data_providers.py
+++ b/omero_parade/csv_filters/data_providers.py
@@ -1,0 +1,122 @@
+#
+# Copyright (c) 2018 University of Dundee.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import logging
+import csv
+from io import StringIO
+
+from omero.model import FileAnnotationI
+from omero_parade.utils import get_well_image_ids
+from .omero_filters import name_to_word
+
+logger = logging.getLogger(__name__)
+
+
+def get_csv_files(conn, obj_type, obj_id):
+
+    csv_files = []
+
+    obj = conn.getObject(obj_type, obj_id)
+    for ann in obj.listAnnotations():
+        if (ann.OMERO_TYPE == FileAnnotationI):
+            if ann.file.name.val.endswith('.csv'):
+                csv_files.append(ann)
+
+    return csv_files
+
+
+def get_csv_column_names(file_ann):
+    chs = [ch.decode() for ch in file_ann.getFile().getFileInChunks()]
+    text = "".join(chs)
+    csv_reader = csv.reader(StringIO(text), delimiter=',')
+
+    # return first row
+    return next(csv_reader)
+
+
+def get_names(conn, obj_type, obj_id):
+    csv_files = get_csv_files(conn, obj_type, obj_id)
+
+    names = []
+    for f in csv_files:
+        fname = f.file.name.val
+        print(fname)
+        for col in get_csv_column_names(f):
+            names.append("%s %s" % (fname, col))
+    return names
+
+
+def get_dataproviders(request, conn):
+    obj_types = ["project", "dataset", "screen", "plate"]
+
+    for dtype in obj_types:
+        if request.GET.get(dtype) is not None:
+            obj_id = request.GET.get(dtype)
+            return get_names(conn, dtype, obj_id)
+
+
+def get_data(request, data_name, conn):
+    """Return table data for images."""
+    print('data_name', data_name)
+    # Find matching csv file...
+    obj_types = ["project", "dataset", "screen", "plate"]
+
+    csv_file = None
+    for dtype in obj_types:
+        if request.GET.get(dtype) is not None:
+            obj_id = request.GET.get(dtype)
+            for file_ann in get_csv_files(conn, dtype, obj_id):
+                if data_name.startswith(file_ann.getFile().name):
+                    csv_file = file_ann.getFile()
+                    break
+    
+    if csv_file is None:
+        return {}
+
+    # Open file and read the column we need:
+    chs = [ch.decode() for ch in csv_file.getFileInChunks()]
+    text = "".join(chs)
+    csv_reader = csv.reader(StringIO(text), delimiter=',')
+
+    first_row = [c.strip() for c in next(csv_reader)]
+
+    # Find column. data_name is 'file_name col_name'
+    col_name = data_name.replace(file_ann.getFile().name, "").strip()
+    if col_name not in first_row:
+        return {'Error': 'Column %s not found' % col_name}
+
+    data_col_idx = first_row.index(col_name)
+    well_to_img = None
+    # TODO handle SPW, Well
+    # handle csv from Batch_ROI_Export.py which uses 'image_id'
+    if 'Image' not in first_row and 'image_id' in first_row:
+        first_row[first_row.index('image_id')] = 'Image'
+
+
+    img_col_idx = first_row.index('Image')
+    table_data = {}
+
+    for row in csv_reader:
+        img_id = row[img_col_idx].strip()
+        value = row[data_col_idx].strip()
+        try:
+            value = float(value)
+        except ValueError:
+            pass
+        table_data[img_id] = value
+
+    return table_data

--- a/omero_parade/csv_filters/data_providers.py
+++ b/omero_parade/csv_filters/data_providers.py
@@ -20,8 +20,6 @@ import csv
 from io import StringIO
 
 from omero.model import FileAnnotationI
-from omero_parade.utils import get_well_image_ids
-from .omero_filters import name_to_word
 
 logger = logging.getLogger(__name__)
 
@@ -83,7 +81,7 @@ def get_data(request, data_name, conn):
                 if data_name.startswith(file_ann.getFile().name):
                     csv_file = file_ann.getFile()
                     break
-    
+
     if csv_file is None:
         return {}
 
@@ -100,12 +98,10 @@ def get_data(request, data_name, conn):
         return {'Error': 'Column %s not found' % col_name}
 
     data_col_idx = first_row.index(col_name)
-    well_to_img = None
     # TODO handle SPW, Well
     # handle csv from Batch_ROI_Export.py which uses 'image_id'
     if 'Image' not in first_row and 'image_id' in first_row:
         first_row[first_row.index('image_id')] = 'Image'
-
 
     img_col_idx = first_row.index('Image')
     table_data = {}

--- a/omero_parade/csv_filters/data_providers.py
+++ b/omero_parade/csv_filters/data_providers.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 University of Dundee.
+# Copyright (c) 2020 University of Dundee.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/omero_parade/csv_filters/data_providers.py
+++ b/omero_parade/csv_filters/data_providers.py
@@ -23,6 +23,8 @@ from omero.model import FileAnnotationI
 from omero_parade import parade_settings
 
 logger = logging.getLogger(__name__)
+
+OBJ_TYPES = ["project", "dataset", "screen", "plate"]
 MAX_CSV_SIZE = parade_settings.MAX_CSV_SIZE
 
 
@@ -63,9 +65,7 @@ def get_names(conn, obj_type, obj_id):
 
 
 def get_dataproviders(request, conn):
-    obj_types = ["project", "dataset", "screen", "plate"]
-
-    for dtype in obj_types:
+    for dtype in OBJ_TYPES:
         if request.GET.get(dtype) is not None:
             obj_id = request.GET.get(dtype)
             return get_names(conn, dtype, obj_id)
@@ -75,10 +75,8 @@ def get_data(request, data_name, conn):
     """Return table data for images."""
     print('data_name', data_name)
     # Find matching csv file...
-    obj_types = ["project", "dataset", "screen", "plate"]
-
     csv_file = None
-    for dtype in obj_types:
+    for dtype in OBJ_TYPES:
         if request.GET.get(dtype) is not None:
             obj_id = request.GET.get(dtype)
             for file_ann in get_csv_annotations(conn, dtype, obj_id):

--- a/omero_parade/csv_filters/data_providers.py
+++ b/omero_parade/csv_filters/data_providers.py
@@ -73,7 +73,6 @@ def get_dataproviders(request, conn):
 
 def get_data(request, data_name, conn):
     """Return table data for images."""
-    print('data_name', data_name)
     # Find matching csv file...
     csv_file = None
     for dtype in OBJ_TYPES:

--- a/omero_parade/csv_filters/omero_filters.py
+++ b/omero_parade/csv_filters/omero_filters.py
@@ -26,7 +26,7 @@ from io import StringIO
 from omero.model import FileAnnotationI
 from omero_parade.views import NUMPY_GT_1_11_0
 from omero_parade.utils import get_well_image_ids
-from .data_providers import get_csv_annotations
+from .data_providers import get_csv_annotations, OBJ_TYPES
 
 logger = logging.getLogger(__name__)
 
@@ -42,12 +42,9 @@ def name_to_word(name):
 
 
 def get_filters(request, conn):
-
-    obj_types = ["project", "dataset", "screen", "plate"]
-
     obj_type = None
     obj_id = None
-    for o in obj_types:
+    for o in OBJ_TYPES:
         if request.GET.get(o) is not None:
             obj_id = request.GET.get(o)
             obj_type = o
@@ -71,11 +68,9 @@ def get_image_well_ids(conn, plate_id):
 
 def get_script(request, script_name, conn):
     """Return a JS function to filter images by various params."""
-    obj_types = ["project", "dataset", "screen", "plate"]
-
     obj = None
     obj_type = None
-    for t in obj_types:
+    for t in OBJ_TYPES:
         if request.GET.get(t) is not None:
             obj_id = int(request.GET.get(t))
             obj = conn.getObject(t, obj_id)

--- a/omero_parade/csv_filters/omero_filters.py
+++ b/omero_parade/csv_filters/omero_filters.py
@@ -149,20 +149,23 @@ def get_script(request, script_name, conn):
     for name, values in column_data.items():
 
         try:
-            values = [float(v) for v in values]
+            # try to convert to number (if not empty string)
+            values = [float(v) if len(v) > 0 else v for v in values]
         except ValueError:
             pass
         else:
             table_data[name] = values
             table_cols.append(name)
-            minima[name] = numpy.amin(values).item()
-            maxima[name] = numpy.amax(values).item()
+            # only use numbers (not empty strings) for histogram...
+            nums = [v for v in values if isinstance(v, float)]
+            minima[name] = numpy.amin(nums).item()
+            maxima[name] = numpy.amax(nums).item()
             bins = 10
             if NUMPY_GT_1_11_0:
                 # numpy.histogram() only supports bin calculation
                 # from 1.11.0 onwards
                 bins = 'auto'
-            histogram, bin_edges = numpy.histogram(values, bins=bins)
+            histogram, bin_edges = numpy.histogram(nums, bins=bins)
             histograms[name] = histogram.tolist()
 
     # Return a JS function that will be passed an object

--- a/omero_parade/csv_filters/omero_filters.py
+++ b/omero_parade/csv_filters/omero_filters.py
@@ -101,8 +101,6 @@ def get_script(request, script_name, conn):
     if obj_type == 'plate':
         well_ids = get_image_well_ids(conn, obj_id)
 
-    print('well_ids', well_ids)
-
     # read file
     chs = [ch.decode() for ch in file_ann.getFile().getFileInChunks()]
     text = "".join(chs)
@@ -151,6 +149,9 @@ def get_script(request, script_name, conn):
         except ValueError:
             pass
         else:
+            # If ALL empty, ignore
+            if not any(values):
+                continue
             table_data[name] = values
             table_cols.append(name)
             # only use numbers (not empty strings) for histogram...

--- a/omero_parade/csv_filters/omero_filters.py
+++ b/omero_parade/csv_filters/omero_filters.py
@@ -108,9 +108,12 @@ def get_script(request, script_name, conn):
         # First row is column names:
         if column_names is None:
             column_names = [name.strip() for name in row]
-            # Batch_ROI_Export uses 'image_id'
-            if 'Image' not in column_names and 'image_id' in column_names:
-                column_names[column_names.index('image_id')] = 'Image'
+            # Batch_ROI_Export uses 'image_id'. Also support 'image'
+            if 'Image' not in column_names:
+                if 'image_id' in column_names:
+                    column_names[column_names.index('image_id')] = 'Image'
+                elif 'image' in column_names:
+                    column_names[column_names.index('image')] = 'Image'
             for name in column_names:
                 column_data[name] = []
             continue

--- a/omero_parade/csv_filters/omero_filters.py
+++ b/omero_parade/csv_filters/omero_filters.py
@@ -20,20 +20,20 @@ import numpy
 from django.http import JsonResponse
 import logging
 import json
-import re
 import csv
 from io import StringIO
 
-from omero.grid import DoubleColumn, LongColumn
 from omero.model import FileAnnotationI
 from omero_parade.views import NUMPY_GT_1_11_0
 from omero_parade.utils import get_well_image_ids
 
 logger = logging.getLogger(__name__)
 
+
 def name_to_word(name):
     w = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890.'
     return "".join([l if l in w else '_' for l in name])
+
 
 def get_filters(request, conn):
 
@@ -72,7 +72,6 @@ def get_image_well_ids(conn, plate_id):
 def get_script(request, script_name, conn):
     """Return a JS function to filter images by various params."""
     obj_types = ["project", "dataset", "screen", "plate"]
-
 
     obj = None
     obj_type = None
@@ -118,7 +117,7 @@ def get_script(request, script_name, conn):
         # First row is column names:
         if column_names is None:
             column_names = [name.strip() for name in row]
-            # 
+            # Batch_ROI_Export uses 'image_id'
             if 'Image' not in column_names and 'image_id' in column_names:
                 column_names[column_names.index('image_id')] = 'Image'
             for name in column_names:
@@ -193,19 +192,19 @@ def get_script(request, script_name, conn):
     """ % json.dumps(table_data)
 
     filter_params = [{'name': 'column_name',
-                        'type': 'text',
-                        'values': table_cols,
-                        'default': table_cols[0],
-                        'minima': minima,
-                        'maxima': maxima,
-                        'histograms': histograms},
-                        {'name': 'operator',
-                        'type': 'text',
-                        'values': ['>', '=', '<'],
-                        'default': '>'},
-                        {'name': 'count',
-                        'type': 'number',
-                        'default': ''}]
+                      'type': 'text',
+                      'values': table_cols,
+                      'default': table_cols[0],
+                      'minima': minima,
+                      'maxima': maxima,
+                      'histograms': histograms},
+                     {'name': 'operator',
+                      'type': 'text',
+                      'values': ['>', '=', '<'],
+                      'default': '>'},
+                     {'name': 'count',
+                      'type': 'number',
+                      'default': ''}]
     return JsonResponse(
         {
             'f': f,

--- a/omero_parade/csv_filters/omero_filters.py
+++ b/omero_parade/csv_filters/omero_filters.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 University of Dundee.
+# Copyright (c) 2020 University of Dundee.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/omero_parade/csv_filters/omero_filters.py
+++ b/omero_parade/csv_filters/omero_filters.py
@@ -1,0 +1,210 @@
+#
+# Copyright (c) 2018 University of Dundee.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import numpy
+
+from django.http import JsonResponse
+import logging
+import json
+import re
+import csv
+from io import StringIO
+
+from omero.grid import DoubleColumn, LongColumn
+from omero.model import FileAnnotationI
+from omero_parade.views import NUMPY_GT_1_11_0
+from omero_parade.utils import get_well_image_ids
+
+logger = logging.getLogger(__name__)
+
+def name_to_word(name):
+    w = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890.'
+    return "".join([l if l in w else '_' for l in name])
+
+def get_filters(request, conn):
+
+    obj_types = ["project", "dataset", "screen", "plate"]
+
+    obj = None
+    for ob_type in obj_types:
+        if request.GET.get(ob_type) is not None:
+            obj_id = request.GET.get(ob_type)
+            obj = conn.getObject(ob_type, obj_id)
+            break
+
+    if obj is None:
+        return []
+
+    csv_names = []
+    for ann in obj.listAnnotations():
+        if (ann.OMERO_TYPE == FileAnnotationI):
+            if ann.file.name.val.endswith('csv'):
+                csv_names.append(ann.file.name.val)
+
+    csv_names = [name_to_word(name) for name in csv_names]
+    return csv_names
+
+
+def get_image_well_ids(conn, plate_id):
+    """Return dict of {image_id: well_id} for plate."""
+
+    img_to_well = {}
+    well_to_img = get_well_image_ids(conn, plate_id)
+    for well_id, img_id in well_to_img.items():
+        img_to_well[img_id] = well_id
+    return img_to_well
+
+
+def get_script(request, script_name, conn):
+    """Return a JS function to filter images by various params."""
+    obj_types = ["project", "dataset", "screen", "plate"]
+
+
+    obj = None
+    obj_type = None
+    for t in obj_types:
+        if request.GET.get(t) is not None:
+            obj_id = int(request.GET.get(t))
+            obj = conn.getObject(t, obj_id)
+            obj_type = t
+            break
+
+    if obj is None:
+        return JsonResponse(
+            {'Error': 'Specify object e.g. ?project=1'})
+
+    print('name', script_name)
+
+    # find csv file by name
+    file_ann = None
+    for ann in obj.listAnnotations():
+        if (ann.OMERO_TYPE == FileAnnotationI):
+            if name_to_word(ann.file.name.val) == script_name:
+                file_ann = ann
+
+    if file_ann is None:
+        return JsonResponse({'Error': 'csv file %s not found' % script_name})
+
+    # Prepare to find Well ID if needed
+    well_ids = {}
+    if obj_type == 'plate':
+        well_ids = get_image_well_ids(conn, obj_id)
+
+    print('well_ids', well_ids)
+
+    # read file
+    chs = [ch.decode() for ch in file_ann.getFile().getFileInChunks()]
+    text = "".join(chs)
+    csv_reader = csv.reader(StringIO(text), delimiter=',')
+
+    # process each row, adding values to each column...
+    column_names = None
+    column_data = {}
+    for row in csv_reader:
+        # First row is column names:
+        if column_names is None:
+            column_names = [name.strip() for name in row]
+            # 
+            if 'Image' not in column_names and 'image_id' in column_names:
+                column_names[column_names.index('image_id')] = 'Image'
+            for name in column_names:
+                column_data[name] = []
+            continue
+
+        # ignore empty rows
+        if not any(row):
+            continue
+
+        for name, value in zip(column_names, row):
+            column_data[name].append(value.strip())
+
+    # If Plate, we want Well IDs
+    if obj_type == 'plate' and 'Image' in column_names:
+        if 'Well' not in column_names:
+            iids = column_data['Image']
+            column_data['Well'] = [well_ids.get(int(iid)) for iid in iids]
+
+    minima = {}
+    maxima = {}
+    histograms = {}
+    table_data = {}
+    table_cols = []
+
+    # process each column, try convert to numbers
+    # currently the UI *ONLY* supports number columns - ignore others
+    for name, values in column_data.items():
+
+        try:
+            values = [float(v) for v in values]
+        except ValueError:
+            pass
+        else:
+            table_data[name] = values
+            table_cols.append(name)
+            minima[name] = numpy.amin(values).item()
+            maxima[name] = numpy.amax(values).item()
+            bins = 10
+            if NUMPY_GT_1_11_0:
+                # numpy.histogram() only supports bin calculation
+                # from 1.11.0 onwards
+                bins = 'auto'
+            histogram, bin_edges = numpy.histogram(values, bins=bins)
+            histograms[name] = histogram.tolist()
+
+    # Return a JS function that will be passed an object
+    # e.g. {'type': 'Image', 'id': 1}
+    # and should return true or false
+    f = """(function filter(data, params) {
+        if (isNaN(params.count) || params.count == '') return true;
+        var table_data = %s;
+        var rowIndex;
+        if (data.wellId) {
+            rowIndex = table_data.Well.indexOf(data.wellId);
+        } else if (table_data.Image) {
+            rowIndex = table_data.Image.indexOf(data.id);
+        } else {
+            return false
+        }
+        if (rowIndex) {
+
+        }
+        var value = table_data[params.column_name][rowIndex];
+        if (params.operator === '=') return value == params.count;
+        if (params.operator === '<') return value < params.count;
+        if (params.operator === '>') return value > params.count;
+    })
+    """ % json.dumps(table_data)
+
+    filter_params = [{'name': 'column_name',
+                        'type': 'text',
+                        'values': table_cols,
+                        'default': table_cols[0],
+                        'minima': minima,
+                        'maxima': maxima,
+                        'histograms': histograms},
+                        {'name': 'operator',
+                        'type': 'text',
+                        'values': ['>', '=', '<'],
+                        'default': '>'},
+                        {'name': 'count',
+                        'type': 'number',
+                        'default': ''}]
+    return JsonResponse(
+        {
+            'f': f,
+            'params': filter_params,
+        })

--- a/omero_parade/parade_settings.py
+++ b/omero_parade/parade_settings.py
@@ -24,10 +24,11 @@ from omeroweb.settings import process_custom_settings, report_settings
 # load settings
 PARADE_SETTINGS_MAPPING = {
 
-    "omero.web.parade.max_csv_size": ["MAX_CSV_SIZE", 100000000, int,
-    ("Maximum supported size of CSV files in bytes, to avoid trying \
-     to load very large files for filtering or plotting. \
-     The default is 100MB")],
+    "omero.web.parade.max_csv_size":
+        ["MAX_CSV_SIZE", 100000000, int,
+         ("Maximum supported size of CSV files in bytes, to avoid trying \
+          to load very large files for filtering or plotting. \
+          The default is 100MB")],
 
     "omero.web.parade.filters":
         ["PARADE_FILTERS",

--- a/omero_parade/parade_settings.py
+++ b/omero_parade/parade_settings.py
@@ -27,7 +27,7 @@ PARADE_SETTINGS_MAPPING = {
     "omero.web.parade.filters":
         ["PARADE_FILTERS",
          '["omero_parade", "omero_parade.annotation_filters", '
-         '"omero_parade.table_filters"]',
+         '"omero_parade.table_filters", "omero_parade.csv_filters"]',
          json.loads,
          ("Filters for filtering data. Each is a python module \
           that contains an omero_filter module"

--- a/omero_parade/parade_settings.py
+++ b/omero_parade/parade_settings.py
@@ -24,6 +24,11 @@ from omeroweb.settings import process_custom_settings, report_settings
 # load settings
 PARADE_SETTINGS_MAPPING = {
 
+    "omero.web.parade.max_csv_size": ["MAX_CSV_SIZE", 100000000, int,
+    ("Maximum supported size of CSV files in bytes, to avoid trying \
+     to load very large files for filtering or plotting. \
+     The default is 100MB")],
+
     "omero.web.parade.filters":
         ["PARADE_FILTERS",
          '["omero_parade", "omero_parade.annotation_filters", '

--- a/omero_parade/table_filters/data_providers.py
+++ b/omero_parade/table_filters/data_providers.py
@@ -18,9 +18,7 @@
 import logging
 
 from omero.model import OriginalFileI
-from omero_parade.utils import get_dataset_image_ids, \
-    get_project_image_ids, \
-    get_well_image_ids
+from omero_parade.utils import get_well_image_ids
 try:
     from omeroweb.webgateway.views import _bulk_file_annotations
 except ImportError:

--- a/omero_parade/table_filters/data_providers.py
+++ b/omero_parade/table_filters/data_providers.py
@@ -92,13 +92,9 @@ def get_data(request, data_name, conn):
         project_id, dataset_id, plate_id, field_id
     ))
 
-    if project_id is not None:
-        img_ids = get_project_image_ids(conn, project_id)
-    elif dataset_id is not None:
-        img_ids = get_dataset_image_ids(conn, dataset_id)
-    elif plate_id is not None and field_id is not None:
+    if plate_id is not None and field_id is not None:
         # dict of well_id: img_id
-        img_ids = get_well_image_ids(conn, plate_id, field_id)
+        well_to_img_id = get_well_image_ids(conn, plate_id, field_id)
     else:
         return dict()
 
@@ -141,12 +137,12 @@ def get_data(request, data_name, conn):
             index_ids = column_data[0].values
             values = column_data[1].values
 
-            for index_id, value in zip(index_ids, values):
+            for obj_id, value in zip(index_ids, values):
                 if project_id is not None or dataset_id is not None:
-                    table_data[index_id] = value
+                    table_data[obj_id] = value
                 if plate_id is not None:
                     try:
-                        table_data[img_ids[index_id]] = value
+                        table_data[well_to_img_id[obj_id]] = value
                     except KeyError:
                         # The table may have data from different plates.
                         # We only have a dictionary of well_id: img_id for

--- a/omero_parade/table_filters/data_providers.py
+++ b/omero_parade/table_filters/data_providers.py
@@ -93,7 +93,7 @@ def get_data(request, data_name, conn):
     if plate_id is not None and field_id is not None:
         # dict of well_id: img_id
         well_to_img_id = get_well_image_ids(conn, plate_id, field_id)
-    else:
+    elif project_id is None and dataset_id is None:
         return dict()
 
     if data_name.startswith("Table_"):


### PR DESCRIPTION
This adds CSV support to OMERO.parade for filtering and table_columns / scatter plot.

To test:
 - Attach CSV to Project or Plate. (NB: not tested on Dataset yet). Should have an ```Image``` column or ```image_id``` column (NB: this can be created with ```Batch_ROI_Export.py``` but may give confusing results if there is more than 1 row per Image ID.
 - In parade, the Filter drop-down list should list each ```.csv``` file on the Project/Plate. NB: only alpha-numeric characters, underscore and ```.``` are allowed in this list since parade UI uses the chosen option to the URL directly. Other characters are currently replaced by underscore. Alternative option is to relax the URL regex to allow more flexibility. Currently this is ```r'^filters/script/(?P<filter_name>[\w.]+)/$'```
 - Choose a .csv filter, the filter should load as for OMERO.tables. NB: Only numerical columns are used - any columns with non-numbers in will be ignored.
 - Choose a column should allow filtering by number as for Tables data
 - Adding data to the table layout and scatter plot: For each csv file, all the columns are listed in the format ```file.csv column``` in the drop-down list. This allows choosing columns from multiple different CSV files.
 - Choosing column should load the data as for OMERO.tables, add the column to the table and allow plotting in the scatter plot.
 - Test this workflow for Project *and* Plate.
 - NB: the Plate at https://merge-ci.openmicroscopy.org/web/webclient/?show=plate-13855 has 1 ROI per image and you can use the ```Batch_ROI_Export.py``` to create a CSV since https://github.com/ome/omero-scripts/pull/156 adds Plate support.
 - To test the CSV file size limit I've set the temp limit at 1MB at https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-web/ with
```omero config set omero.web.parade.max_csv_size 1000000```. Any CSV file over this size should be ignored by filters and 'table data'. The default limit without this setting is 100MB.