### PR TITLE
Support filtering by OMERO.tables on Dataset

### DIFF
--- a/omero_parade/table_filters/omero_filters.py
+++ b/omero_parade/table_filters/omero_filters.py
@@ -37,16 +37,20 @@ def get_script(request, script_name, conn):
     """Return a JS function to filter images by various params."""
     project_id = request.GET.get('project')
     plate_id = request.GET.get('plate')
+    dataset_id = request.GET.get('dataset')
 
-    if project_id is None and plate_id is None:
+    if project_id is None and plate_id is None and dataset_id is None:
         return JsonResponse(
-            {'Error': 'Neither Project ID nor Plate ID specified'})
+            {'Error': 'Neither Project, Dataset nor Plate ID specified'})
 
     if script_name == "Table":
         table = None
 
         if project_id is not None:
             table = get_table(conn, 'Project', project_id)
+
+        if dataset_id is not None:
+            table = get_table(conn, 'Dataset', dataset_id)
 
         if plate_id is not None:
             table = get_table(conn, 'Screen.plateLinks.child', plate_id)


### PR DESCRIPTION
See https://forum.image.sc/t/using-omero-parade-on-dataset-level-and-image-level-omero-tables/50180

This fixes a limitation of not supporting OMERO.table filtering on Datasets.

To test:
 - I tested this by linking an OMERO.table (File Annotation on a Project) to one of the Datasets in the Project:
 
```
$ omero obj new DatasetAnnotationLink parent=Dataset:151 child=FileAnnotation:3774 
```

 - I also made the Dataset an Orphan, by removing it from the Project.
 - Then you can choose the Dataset alone in OMERO.parade and filter -> Table

![Screenshot 2021-03-16 at 11 50 19](https://user-images.githubusercontent.com/900055/111304591-d3dcd180-864d-11eb-928f-0abd6af7fb62.png)
