### PR TITLE
Move axes state to Layout from Plot

### DIFF
--- a/src/js/dataView/Layout.js
+++ b/src/js/dataView/Layout.js
@@ -39,6 +39,8 @@ class Layout extends React.Component {
             selectedWellIds: [],
             showDatasets: true,
             thumbnails: {},
+            axisX: undefined,
+            axisY: undefined
         }
         this.setIconSize = this.setIconSize.bind(this);
         this.setLayout = this.setLayout.bind(this);
@@ -47,10 +49,20 @@ class Layout extends React.Component {
         this.handleImageWellClicked = this.handleImageWellClicked.bind(this);
         this.setImagesWellsSelected = this.setImagesWellsSelected.bind(this);
         this.setSelectedWells = this.setSelectedWells.bind(this);
+        this.setAxisX = this.setAxisX.bind(this);
+        this.setAxisY = this.setAxisY.bind(this);
     }
 
     setIconSize(size) {
         this.setState({iconSize: parseInt(size, 10)});
+    }
+
+    setAxisX(colName) {
+        this.setState({axisX: colName});
+    }
+
+    setAxisY(colName) {
+        this.setState({ axisY: colName });
     }
 
     setLayout(layout) {
@@ -257,6 +269,10 @@ class Layout extends React.Component {
                     handleImageWellClicked = {this.handleImageWellClicked}
                     setImagesWellsSelected = {this.setImagesWellsSelected}
                     thumbnails={this.state.thumbnails}
+                    setAxisX={this.setAxisX}
+                    setAxisY={this.setAxisY}
+                    axisX={this.state.axisX}
+                    axisY={this.state.axisY}
                     />)
         } else if (this.props.plateData) {
             imageComponent = (

--- a/src/js/dataView/plot/DataPlot.js
+++ b/src/js/dataView/plot/DataPlot.js
@@ -31,11 +31,6 @@ class DataPlot extends React.Component {
 
     constructor(props) {
         super(props);
-        this.state = {
-            xAxisName: undefined,
-            yAxisName: undefined,
-        }
-        this.setAxisName = this.setAxisName.bind(this);
     }
 
     setAxisName(axis, event, otherAxis) {
@@ -44,9 +39,11 @@ class DataPlot extends React.Component {
         // user picks one to change, we set both.
         let name = event.target.value;
         if (axis === 'x') {
-            this.setState({xAxisName: name, yAxisName: otherAxis});
+            this.props.setAxisX(name);
+            this.props.setAxisY(otherAxis);
         } else {
-            this.setState({yAxisName: name, xAxisName: otherAxis});
+            this.props.setAxisY(name);
+            this.props.setAxisX(otherAxis);
         }
     }
 
@@ -98,8 +95,8 @@ class DataPlot extends React.Component {
         let {imgJson, iconSize, tableData,
              handleImageWellClicked, selectedWellIds} = this.props;
 
-        let xAxisName = this.state.xAxisName;
-        let yAxisName = this.state.yAxisName;
+        let xAxisName = this.props.axisX;
+        let yAxisName = this.props.axisY;
 
         // Available axes are dataTable keys.
         let axisNames = Object.keys(tableData);


### PR DESCRIPTION
Fixes #91

To test:
 - Add data to a table view (3 or more columns) and plot 2 columns in the Plot view
 - Choose preferred X and Y axes
 - Switch back to Table, then return to Plot view. X and Y axes chosen above should still be the same