### PR TITLE
Add openssl-legacy-provider to scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   "license": "AGPL-3.0+",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "watch": "webpack --watch --config webpack.dev.js",
-    "build": "webpack --progress --config webpack.prod.js",
-    "build-dev": "webpack --progress --config webpack.dev.js"
+    "watch": "webpack --watch --openssl-legacy-provider --config webpack.dev.js",
+    "build": "webpack --progress --openssl-legacy-provider --config webpack.prod.js",
+    "build-dev": "webpack --progress --openssl-legacy-provider --config webpack.dev.js"
   },
   "dependencies": {
     "axios": "^0.21.2",


### PR DESCRIPTION
See https://stackoverflow.com/questions/74726224/opensslerrorstack-error03000086digital-envelope-routinesinitialization-e

Aims to fix build failures at https://github.com/ome/omero-parade/actions/runs/4306533013/jobs/7510462772?pr=117