### PR TITLE
JS code handles 'tag' node in jsTree

### DIFF
--- a/src/dataLoader/DataContainer.jsx
+++ b/src/dataLoader/DataContainer.jsx
@@ -293,7 +293,7 @@ class DataContainer extends React.Component {
             )
         }
         if (effectiveRootNode.type === "project"
-                || effectiveRootNode.type === "dataset") {
+                || effectiveRootNode.type === "dataset" || effectiveRootNode.type === "tag") {
             return (
                 <DatasetContainer
                     jstree={jstree}

--- a/src/dataView/Layout.jsx
+++ b/src/dataView/Layout.jsx
@@ -109,6 +109,10 @@ class Layout extends React.Component {
                 plateId = this.props.parentId;
             }
             url += '?plate=' + plateId;
+        } else if (this.props.parentType == "tag") {
+            url += '?tag=' + this.props.parentId;
+        } else {
+            console.log("parentType not handled for dataproviders", this.props.parentType, this.props)
         }
         $.ajax({
             url: url,


### PR DESCRIPTION
Started looking into parade support for the Tags tab - see #138.

 - With the first commit, the JS code handles the "tag" node and passes the ID to URLs but both these endpoints need updating to handle `tag`
 - `/parade/filters/?tag=19900` needs to return a list of supported filters for 'tag'
 - `/parade/dataproviders/?tag=19900` needs to return a list of data providers.

However, support for Tags is a bit more complex than for Projects, Datasets & Screens since the hierarchy below a Tag is a lot more heterogenous. E.g. A Tag can "contain" Plates, Screens, Projects, Datasets, Images.